### PR TITLE
Add day-manager plugin for daily and weekly productivity workflows

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,6 +31,11 @@
       "name": "orientation-tools",
       "source": "./orientation-tools",
       "description": "Codebase orientation skills for mapping structure, interactive exploration, task-driven learning, and health analysis before large changes"
+    },
+    {
+      "name": "day-manager",
+      "source": "./day-manager",
+      "description": "Personal productivity assistant for daily and weekly planning using Todoist, Google Calendar, and Obsidian"
     }
   ]
 }

--- a/day-manager/.claude-plugin/plugin.json
+++ b/day-manager/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "day-manager",
+  "description": "Personal productivity assistant for daily and weekly planning using Todoist, Google Calendar, and Obsidian",
+  "version": "1.0.0",
+  "author": { "name": "Brennan" }
+}

--- a/day-manager/README.md
+++ b/day-manager/README.md
@@ -1,0 +1,176 @@
+# Day Manager
+
+Personal productivity assistant for daily and weekly planning. Three skills that work together to help you start your day with clarity, close it out intentionally, and reflect meaningfully at the end of each week.
+
+**Skills:**
+- `/start-day` — Morning briefing: calendar, priorities, and today's meeting notes
+- `/finish-day` — End-of-day: review, transcript reminder, reschedule, prep tomorrow's notes
+- `/wrap-week` — Weekly narrative recap saved to Obsidian
+
+---
+
+## How the Skills Work Together
+
+The skills form a virtuous cycle:
+
+1. **`/finish-day`** preps tomorrow's meeting notes by appending a date-stamped section to each recurring meeting note in Obsidian.
+2. **`/start-day`** the next morning finds those sections by searching Obsidian for today's date string — no tags or manual setup needed.
+3. **`/wrap-week`** reads the daily notes built up through the week to synthesize a narrative recap.
+
+Run `/finish-day` each evening and `/start-day` each morning for best results. After 2–3 weeks, `/wrap-week` becomes significantly richer.
+
+---
+
+## Prerequisites
+
+All three skills require three MCP servers. Set them up once and they persist in your Claude Code user config.
+
+### 1. Todoist (Official Hosted MCP)
+
+```bash
+claude mcp add --transport http todoist https://ai.todoist.net/mcp --scope user
+```
+
+Then authenticate inside Claude Code:
+```
+/mcp
+```
+Select "todoist" and complete the OAuth flow in your browser.
+
+### 2. Google Calendar
+
+**Step 1:** Create a Google Cloud project and enable the Google Calendar API.
+Follow the authentication guide at: https://github.com/nspady/google-calendar-mcp#authentication
+
+Download your OAuth credentials JSON file (e.g., to `~/gcp-oauth.keys.json`).
+
+**Step 2:** Register the MCP server:
+```bash
+claude mcp add --transport stdio \
+  --env GOOGLE_OAUTH_CREDENTIALS=$HOME/gcp-oauth.keys.json \
+  google-calendar --scope user \
+  -- npx -y @cocal/google-calendar-mcp
+```
+
+The first time Claude Code uses this server it will open a browser for OAuth consent.
+
+### 3. Obsidian (mcpvault — filesystem direct)
+
+No Obsidian plugins required. Works even when Obsidian is closed.
+
+```bash
+claude mcp add --transport stdio \
+  --env VAULT_PATH=/path/to/your/vault \
+  obsidian --scope user \
+  -- npx -y mcpvault
+```
+
+Replace `/path/to/your/vault` with the absolute path to your Obsidian vault (e.g., `/Users/yourname/Documents/MyVault`).
+
+---
+
+## Obsidian Vault Setup
+
+Enable the **Daily Notes** core plugin in Obsidian (Settings → Core Plugins → Daily Notes):
+- Folder: `Daily Notes`
+- Date format: `YYYY-MM-DD`
+- Template: optional — `/start-day` will create notes with its own template
+
+The skills assume this folder structure in your vault:
+
+```
+vault/
+├── Notes/              ← your existing meeting notes (untouched)
+│   ├── 1:1 with Alex.md
+│   ├── Team Standup.md
+│   └── ...
+├── Daily Notes/        ← lightweight day hubs (created by /start-day)
+│   ├── 2026-03-30.md
+│   └── ...
+└── Weekly Recaps/      ← narrative weekly summaries (created by /wrap-week)
+    ├── 2026-W13.md
+    └── ...
+```
+
+Your existing `Notes/` folder is never modified except to append new date sections by `/finish-day`. No content is moved or duplicated.
+
+Override the default paths with arguments if your vault uses different folder names:
+```
+/start-day --daily-notes-path "Journal/Daily" --notes-path "Meetings"
+/wrap-week --weekly-recaps-path "Reviews/Weekly"
+```
+
+---
+
+## Transcript Workflow
+
+By default, `/finish-day` shows a checklist reminder to download transcripts and drop them in your n8n pickup folder.
+
+To automate the trigger, expose your n8n webhook as a single-tool MCP server. A minimal implementation using the MCP SDK:
+
+```javascript
+// n8n-mcp/index.js
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+const server = new McpServer({ name: "n8n", version: "1.0.0" });
+
+server.tool("trigger_transcript_processing", "Trigger n8n transcript workflow", {}, async () => {
+  await fetch(process.env.N8N_WEBHOOK_URL, { method: "POST" });
+  return { content: [{ type: "text", text: "Transcript processing triggered." }] };
+});
+
+await server.connect(new StdioServerTransport());
+```
+
+Register it:
+```bash
+claude mcp add --transport stdio \
+  --env N8N_WEBHOOK_URL=https://your-n8n-instance/webhook/transcripts \
+  n8n --scope user \
+  -- node /path/to/n8n-mcp/index.js
+```
+
+Then pass the server name to finish-day:
+```
+/finish-day --transcript-mcp n8n
+```
+
+---
+
+## Tips
+
+**Daily note as a hub.** Keep meeting content in your long-running `Notes/` files. Daily notes link to those notes and capture your intentions and reflections — no duplication.
+
+**Todoist priority discipline.** The morning briefing ranks tasks by p1/p2. If everything is p1, the ranking loses meaning. Consider a personal rule: max 2–3 p1 tasks at any time.
+
+**Calendar blocking.** Block deep-work time as private Google Calendar events. `/start-day` will include those blocks when suggesting focus windows, making the suggestion more useful.
+
+**Weekly recap as a personal changelog.** ISO week filenames (`2026-W13.md`) sort naturally and are easy to review during quarterly or annual reflections.
+
+**Run `/finish-day` before leaving for the day** — not after. The meeting note prep for tomorrow works best when done while context is fresh.
+
+---
+
+## Skills Reference
+
+| Skill | Description | When to use |
+|---|---|---|
+| `/start-day` | Morning briefing with calendar, tasks, and meeting note links | Each morning before starting work |
+| `/finish-day` | Day close-out: review, reschedule, transcript reminder, tomorrow prep | Each evening before logging off |
+| `/wrap-week` | Mon–Sun narrative recap saved to Obsidian | Friday afternoon or Sunday evening |
+
+### Arguments
+
+**`/start-day`**
+- `--daily-notes-path <path>` — Override default daily notes folder (default: `Daily Notes`)
+- `--notes-path <path>` — Override meeting notes folder (default: `Notes`)
+
+**`/finish-day`**
+- `--daily-notes-path <path>` — Override default daily notes folder
+- `--notes-path <path>` — Override meeting notes folder
+- `--transcript-mcp <server-name>` — Name of an MCP server to trigger for transcript processing
+
+**`/wrap-week`**
+- `--daily-notes-path <path>` — Override default daily notes folder
+- `--weekly-recaps-path <path>` — Override weekly recaps folder (default: `Weekly Recaps`)

--- a/day-manager/skills/finish-day/SKILL.md
+++ b/day-manager/skills/finish-day/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: finish-day
+description: End-of-day wrap-up — reviews completed and incomplete Todoist tasks, recaps today's calendar, reminds about transcripts (with optional n8n MCP trigger), reschedulesincomplete tasks, preps tomorrow's meeting notes in Obsidian, and updates today's daily note with a day summary. Trigger when the user says "finish my day", "wrap up today", "end of day", or invokes /finish-day.
+argument-hint: "[--daily-notes-path <path>] [--notes-path <path>] [--transcript-mcp <server-name>]"
+allowed-tools: Bash, mcp__todoist__get_tasks, mcp__todoist__get_completed_tasks, mcp__todoist__update_task, mcp__todoist__complete_task, mcp__google-calendar__list-events, mcp__google-calendar__get-current-time, mcp__obsidian__read_note, mcp__obsidian__write_note, mcp__obsidian__patch_note, mcp__obsidian__search_notes
+---
+
+# Finish Day
+
+You are helping the user close out their workday. Review what was accomplished, handle transcripts, reschedule incomplete tasks, prep tomorrow's meeting notes, and write an honest day summary.
+
+Default paths (override with arguments):
+- Daily notes: `Daily Notes/` (e.g., `Daily Notes/2026-03-30.md`)
+- Meeting notes: `Notes/`
+
+## Phase 0: Pre-Flight Check
+
+1. Get today's date via Bash: `date +%Y-%m-%d`. Store as TODAY. Get tomorrow's date: `date -v+1d +%Y-%m-%d` (macOS) or `date -d tomorrow +%Y-%m-%d` (Linux). Store as TOMORROW.
+2. Verify all three MCP servers (Todoist, Google Calendar, Obsidian) are reachable with lightweight calls.
+3. If any server fails, STOP and tell the user which one is unreachable with the fix command from the README.
+
+## Phase 1: Gather Today's Data
+
+Run in parallel:
+
+**Completed tasks:** Call `get_completed_tasks` filtered to today. Capture task name and project.
+
+**Still-open tasks:** Call `get_tasks` filtered to due today and overdue. These are tasks that weren't finished.
+
+**Today's calendar:** Call `list-events` for today. This is the record of what meetings/calls actually happened.
+
+**Today's daily note:** Attempt `read_note` on `<daily-notes-path>/TODAY.md`. Read it if it exists — provides morning context.
+
+## Phase 2: Day Review
+
+Present a brief, honest review:
+
+---
+
+**What You Accomplished**
+- Completed Todoist tasks (with project)
+- Calendar events that happened today (meetings, calls)
+
+**Still Open**
+- Incomplete tasks with their original due date
+
+**Day Patterns** (include if notable)
+Note anything worth acknowledging: a p1 task finished, a project milestone hit, or a day that ran long on meetings.
+
+---
+
+## Phase 3: Transcript Reminder
+
+ALWAYS present this step. Never skip it.
+
+---
+
+**Transcript Upload**
+
+If you recorded any meetings or conversations today, now is the time to download and save them to your n8n pickup folder.
+
+```
+[ ] Downloaded all transcripts from your recording tool
+[ ] Saved to n8n pickup folder
+```
+
+*If `--transcript-mcp <server-name>` was passed and that MCP server is available:*
+> I see the `<server-name>` MCP server is configured. Would you like me to trigger transcript processing now? Tell me which tool to call and I'll run it.
+> Then call the tool the user specifies on that server.
+
+*If no transcript MCP is configured:*
+> To automate this in the future, expose your n8n webhook as an MCP server and pass `--transcript-mcp <server-name>` to this skill. See the README for details.
+
+---
+
+Options for the user:
+1. **Done** — transcripts are handled
+2. **Skip** — no transcripts today
+3. **Remind me later** — note it in the daily note
+
+## Phase 4: Reschedule Incomplete Tasks
+
+If there are no incomplete tasks, skip this phase.
+
+Present all incomplete tasks at once and ask the user what to do with each:
+- **Tomorrow** — update due date to TOMORROW via `update_task`
+- **Later this week** — ask for specific day
+- **Next week** — update to next Monday
+- **Deprioritize** — set no due date or lower priority
+- **Done / Cancel** — mark complete via `complete_task`
+
+Collect all decisions first, then execute all `update_task` and `complete_task` calls together in one batch.
+
+## Phase 5: Prep Tomorrow's Meeting Notes
+
+This is what enables `/start-day` to find relevant meeting notes via date-string search tomorrow morning.
+
+1. Call `list-events` for TOMORROW to get tomorrow's calendar events.
+2. For each named recurring meeting (skip one-offs that don't have a corresponding note):
+   a. Call `search_notes` with the meeting title as the query to find the long-running note in `Notes/`
+   b. If a note is found with a confidence match: call `patch_note` to append this section to the end of the note:
+
+```markdown
+
+## TOMORROW
+
+### Agenda
+
+### Notes
+
+```
+
+   Replace `TOMORROW` with the actual date string (e.g., `## 2026-03-31`).
+
+   c. If no matching note is found: ask the user — "I don't see a note for '[Meeting Name]'. Want me to create one in Notes/?"
+   d. If the user confirms, use `write_note` to create `Notes/<Meeting Name>.md` with the section stub.
+
+3. Tell the user which notes were updated: "Prepped sections in: [[1:1 with Alex]], [[Team Standup]]"
+
+## Phase 6: Tomorrow Preview (optional)
+
+Ask: "Want a quick look at what's lined up for tomorrow?"
+
+If yes, present:
+- Tomorrow's calendar events (already fetched in Phase 5)
+- Todoist tasks due tomorrow (call `get_tasks` filtered to TOMORROW)
+
+Keep it brief — this is a preview, not a full briefing.
+
+## Phase 7: Update Today's Daily Note
+
+Use `patch_note` to append an "End of Day" section to today's daily note. If no daily note exists, use `write_note` to create a minimal one.
+
+The section to append:
+
+```markdown
+
+## End of Day
+*Completed by /finish-day*
+
+### Accomplished
+[Completed tasks and notable meetings]
+
+### Carried Forward
+[Rescheduled tasks and where they went — e.g., "Fix auth bug → tomorrow", "Update docs → deprioritized"]
+
+### Reflection
+[Ask the user: "Any reflections on today you'd like to capture?" Then write their response here, or leave a placeholder if they skip.]
+```
+
+Ask before writing the reflection: "Any thoughts on today to capture in your notes?" Include their response verbatim (or "—" if they skip).
+
+## Quality Notes
+
+- The day review should be honest — acknowledge what didn't happen without judgment
+- Meeting note prep (Phase 5) is the most important step for enabling tomorrow's start-day flow; don't skip it
+- The transcript reminder (Phase 3) must always be shown, even if brief
+- Batch all Todoist updates — don't call `update_task` one at a time while the user is still deciding

--- a/day-manager/skills/start-day/SKILL.md
+++ b/day-manager/skills/start-day/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: start-day
+description: Morning briefing — pulls today's Google Calendar events and Todoist tasks, finds relevant meeting notes in Obsidian by searching for today's date, and synthesizes a prioritized daily plan. Optionally creates today's daily note. Trigger when the user says "start my day", "morning briefing", or invokes /start-day.
+argument-hint: "[--daily-notes-path <path>] [--notes-path <path>]"
+allowed-tools: Bash, mcp__todoist__get_tasks, mcp__google-calendar__list-events, mcp__google-calendar__get-current-time, mcp__obsidian__search_notes, mcp__obsidian__read_note, mcp__obsidian__write_note, mcp__obsidian__patch_note, mcp__obsidian__get_frontmatter
+---
+
+# Start Day
+
+You are helping the user plan their day. Pull data from their three productivity tools, synthesize it into a clear morning briefing, and optionally create today's daily note.
+
+Default paths (override with arguments):
+- Daily notes: `Daily Notes/` (e.g., `Daily Notes/2026-03-30.md`)
+- Meeting notes: `Notes/`
+
+## Phase 0: Pre-Flight Check
+
+1. Get today's date by running `date +%Y-%m-%d` via Bash. Store this as TODAY (e.g., `2026-03-30`). Also get the day name: `date +%A`.
+2. Get today's timezone by calling `get-current-time` on the google-calendar server.
+3. Verify each MCP server is reachable by attempting a lightweight call:
+   - **Todoist**: call `get_tasks` with an empty or minimal filter
+   - **Google Calendar**: already verified via `get-current-time`
+   - **Obsidian**: call `search_notes` with query `daily-note`
+
+If any server fails, STOP and tell the user exactly which server is unreachable and the `claude mcp add` command from the README to fix it. Do NOT proceed without all three servers.
+
+## Phase 1: Gather Today's Data
+
+Run these in parallel where possible:
+
+**Calendar:** Call `list-events` for today (midnight to midnight in the user's timezone). For each event capture: title, start/end time, attendees, video call link if present.
+
+**Todoist — due today:** Call `get_tasks` filtered to tasks due today. For each task capture: name, project, priority (p1–p4), any due time.
+
+**Todoist — overdue:** Call `get_tasks` filtered to overdue tasks. For each task note how many days overdue.
+
+**Meeting notes for today:** Call `search_notes` with the query TODAY (the date string, e.g., `2026-03-30`). This surfaces any long-running meeting note that has a section for today — no manual tagging needed. The section was added by `/finish-day` the previous evening.
+
+**Existing daily note:** Attempt `read_note` on `<daily-notes-path>/TODAY.md`. If it exists, read its content — the user may have already started it.
+
+## Phase 2: Synthesize Morning Briefing
+
+Present the briefing in this structure:
+
+---
+
+### Good [morning/afternoon] — [Day Name], [Full Date]
+
+**At a Glance**
+[X] calendar events · [Y] tasks due today · [Z] overdue
+
+**Calendar**
+List events chronologically with start and end times. Flag any day with more than 4 hours of back-to-back meetings. Include a note link (e.g., `[[Meeting Name]]`) if a matching meeting note was found in Phase 1.
+
+**Top Priorities**
+Synthesize Todoist p1 and p2 tasks into a ranked list of 3–5 focus areas. Briefly explain the ranking (e.g., "p1, overdue 2 days"). Keep it scannable.
+
+**Overdue Items**
+List overdue tasks grouped by how overdue they are. For anything overdue more than 3 days, flag it explicitly.
+
+**Suggested Focus Blocks** (include only if there are clear gaps in the calendar)
+Based on gaps between calendar events, suggest 1–3 focus windows for deep work. Example: "9:00–11:00 — clear window before standup, good for [top priority task]."
+
+**Today's Meeting Notes**
+If meeting notes were found for today (Phase 1), list them with their Obsidian note title and a brief reminder of context if visible in the section content.
+
+---
+
+## Phase 3: Create Daily Note (optional)
+
+Ask: "Would you like me to create today's daily note in Obsidian?"
+
+If yes (or if the user passed `--create-daily-note`):
+- If no daily note exists, use `write_note` to create `<daily-notes-path>/TODAY.md` with this template:
+
+```markdown
+---
+date: TODAY
+tags: [daily-note]
+---
+
+# [Day Name], [Full Date]
+
+## Morning Intentions
+
+[Top 3 priorities from Phase 2]
+
+## Schedule
+
+[Calendar events from Phase 1, one per line with times]
+
+## Meeting Notes
+
+[Links to today's relevant meeting notes found in Phase 1, e.g., [[1:1 with Alex]], [[Team Standup]]]
+
+## Notes
+
+## End of Day
+<!-- Filled in by /finish-day -->
+```
+
+- If a daily note already exists, use `patch_note` to add or update only the "Morning Intentions" section rather than overwriting the file.
+
+## Quality Notes
+
+- Always use the date from Bash (`date` command), never infer it
+- Priorities should reflect both urgency (due dates, overdue status) and importance (Todoist priority levels)
+- Keep the briefing scannable — headers and bullets, not paragraphs
+- Meeting note links in the daily note should use Obsidian wiki-link format: `[[Note Name]]`
+- If no meeting notes are found for today via date search, that's fine — just omit that section

--- a/day-manager/skills/wrap-week/SKILL.md
+++ b/day-manager/skills/wrap-week/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: wrap-week
+description: Weekly retrospective — pulls completed Todoist tasks, Google Calendar events, and Obsidian daily notes from Monday through today, synthesizes a narrative weekly recap, saves it to Obsidian, and previews next week. Run on Friday afternoon or Sunday evening. Trigger when the user says "wrap up my week", "weekly recap", "weekly review", or invokes /wrap-week.
+argument-hint: "[--daily-notes-path <path>] [--weekly-recaps-path <path>]"
+allowed-tools: Bash, mcp__todoist__get_completed_tasks, mcp__todoist__get_tasks, mcp__google-calendar__list-events, mcp__google-calendar__get-current-time, mcp__obsidian__read_note, mcp__obsidian__write_note, mcp__obsidian__search_notes
+---
+
+# Wrap Week
+
+You are helping the user write a meaningful weekly retrospective. This is a narrative synthesis, not a list dump. The goal is to tell the story of the week in a way that helps the user see patterns, celebrate progress, and prepare thoughtfully for next week.
+
+Default paths (override with arguments):
+- Daily notes: `Daily Notes/`
+- Weekly recaps: `Weekly Recaps/`
+
+## Phase 0: Pre-Flight Check and Date Setup
+
+1. Get today's date and compute the week range via Bash:
+```bash
+# Get today
+TODAY=$(date +%Y-%m-%d)
+# Get Monday of current week (macOS)
+WEEK_START=$(date -v-$(date +%u)d +%Y-%m-%d 2>/dev/null || date -d "last monday" +%Y-%m-%d)
+# ISO week number
+WEEK_NUM=$(date +%Y-W%V)
+echo "TODAY=$TODAY WEEK_START=$WEEK_START WEEK_NUM=$WEEK_NUM"
+```
+
+Store WEEK_START (Monday), TODAY (end of week), and WEEK_NUM (e.g., `2026-W13`).
+
+2. Verify all three MCP servers are reachable. If any fails, STOP and provide the fix command.
+3. Get timezone via `get-current-time` on the google-calendar server.
+
+## Phase 1: Gather the Week's Data
+
+Run in parallel where possible:
+
+**Completed tasks:** Call `get_completed_tasks` filtered from WEEK_START to TODAY. Group by project. Note the total count.
+
+**Incomplete/carried tasks:** Call `get_tasks` filtered to overdue. These are things that were planned but didn't happen this week.
+
+**Calendar events:** Call `list-events` for WEEK_START through TODAY. Group by day. Note total meeting hours.
+
+**Daily notes:** For each day Monday through today, attempt `read_note` on `<daily-notes-path>/YYYY-MM-DD.md`. Collect each note that exists. Note how many days have a daily note vs. how many don't.
+
+If daily notes are sparse or missing, acknowledge that and work with what's available from Todoist and Calendar.
+
+## Phase 2: Synthesize the Weekly Narrative
+
+Write a narrative recap — not a data dump. Aim for 300–500 words that tell the story of the week. Synthesize across all sources rather than summarizing each one separately.
+
+Structure the narrative around these themes (use judgment about which are relevant this week):
+
+**The Big Picture**
+What was the dominant theme? Examples: "This was primarily a deep-work week on [project]", "This week was fragmented across multiple initiatives with heavy meeting load", "A recovery week after last week's crunch."
+
+**Key Accomplishments**
+3–5 most significant completions, chosen for impact not volume. Not just the most tasks — the most meaningful ones.
+
+**Meetings and Decisions**
+What did the calendar reveal? Any significant conversations, decisions made, or relationships advanced?
+
+**What Didn't Happen**
+Honest acknowledgment of things that were planned but didn't happen. Frame constructively: "X was planned but got displaced by Y." Flag anything that has been deferred multiple weeks in a row.
+
+**Patterns and Observations** (include if the data supports it)
+Examples: "Most productive days were Tuesday/Thursday when you had clear morning blocks", "Three p1 tasks were deferred again — worth a priority audit", "Meeting load was above average at X hours."
+
+**Tone from Daily Notes** (include only if daily notes exist)
+If end-of-day reflections are present in the daily notes, synthesize the emotional arc of the week honestly.
+
+## Phase 3: Next Week Preview
+
+1. Call `list-events` for next Monday through Friday.
+2. Call `get_tasks` filtered to next week's due dates, plus any still-overdue tasks being carried forward.
+
+Present:
+- **Key commitments** — calendar events next week that may need prep (e.g., presentations, important meetings)
+- **Priorities** — top tasks due next week, especially any carried over from this week
+- **Suggested focus** — given this week's patterns, what should next week's emphasis be?
+
+Ask: "Is there anything you want to set as an intention for next week?" Incorporate their answer into the weekly note.
+
+## Phase 4: Save Weekly Recap to Obsidian
+
+Construct the note filename: `<weekly-recaps-path>/WEEK_NUM.md` (e.g., `Weekly Recaps/2026-W13.md`)
+
+Use `write_note` to save:
+
+```markdown
+---
+date-range: WEEK_START to TODAY
+week: WEEK_NUM
+tags: [weekly-recap]
+---
+
+# Week of [Month Day] — [Month Day, Year]
+
+## The Week in Review
+
+[Narrative from Phase 2 — 300–500 words]
+
+## By the Numbers
+
+- Tasks completed: X
+- Tasks carried forward: Y
+- Meetings: Z ([N] hours)
+- Daily notes written: N/5
+
+## Highlights
+
+[Bullet list of 3–5 key accomplishments]
+
+## Carried Forward
+
+[Incomplete items and where they're headed — e.g., "Fix auth bug → rescheduled to [date]"]
+
+## Next Week
+
+[Preview from Phase 3 — calendar commitments and top priorities]
+
+## Intentions for Next Week
+
+[User's stated intention from Phase 3, or "—" if skipped]
+```
+
+Tell the user where the file was saved: "Saved to `Weekly Recaps/WEEK_NUM.md`"
+
+## Quality Notes
+
+- The narrative should feel human and thoughtful — write it as if explaining the week to a colleague, not generating a report
+- Don't list every completed task — curate and interpret
+- If a week had very few completed tasks or sparse data, be honest about that rather than padding the narrative
+- The recap should be something the user would find meaningful to re-read months later
+- ISO week filenames (`2026-W13.md`) sort naturally in Obsidian and are easy to query for quarterly reviews


### PR DESCRIPTION
Adds three skills backed by Todoist, Google Calendar, and Obsidian MCP servers:
- /start-day: morning briefing with calendar, tasks, and meeting note surfacing via date-string search
- /finish-day: day close-out with transcript reminder, task rescheduling, and tomorrow's meeting note prep
- /wrap-week: Mon–Sun narrative weekly recap saved to Obsidian Weekly Recaps/