### PR TITLE
Add .mcp.json for Cowork compatibility

### DIFF
--- a/day-manager/.mcp.json
+++ b/day-manager/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "todoist": {
+      "type": "http",
+      "url": "https://ai.todoist.net/mcp"
+    }
+  }
+}


### PR DESCRIPTION
Adds Todoist hosted MCP server connection (OAuth-based HTTP transport). Google Calendar and Gmail omitted — Cowork provides its own connectors for those and local stdio servers are not compatible with Cowork.