### PR TITLE
Add cowork plugin for autonomous Todoist task monitoring

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -36,6 +36,11 @@
       "name": "chief-of-staff",
       "source": "./chief-of-staff",
       "description": "AI-enabled executive assistant for daily briefings, weekly planning, project tracking, and end-of-day wrap-up using Todoist, Google Calendar, Gmail, and Obsidian"
+    },
+    {
+      "name": "cowork",
+      "source": "./cowork",
+      "description": "Autonomous task monitor that polls Todoist for tasks labelled @claude and dispatches specialized agents to complete them"
     }
   ]
 }

--- a/cowork/.claude-plugin/plugin.json
+++ b/cowork/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "cowork",
+  "version": "1.0.0",
+  "description": "Autonomous task monitor — polls Todoist for tasks labelled @claude and dispatches specialized agents to complete them.",
+  "author": {
+    "name": "Brennan Meadowcroft"
+  },
+  "keywords": ["todoist", "automation", "agents", "cowork", "tasks"]
+}

--- a/cowork/.mcp.json
+++ b/cowork/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "todoist": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/servers/todoist/server.js"],
+      "env": {
+        "TODOIST_API_TOKEN": "${TODOIST_API_TOKEN}"
+      }
+    }
+  }
+}

--- a/cowork/agents/task-general-agent.md
+++ b/cowork/agents/task-general-agent.md
@@ -1,0 +1,62 @@
+---
+name: task-general-agent
+description: "Execute a general-purpose task assigned to Claude via Todoist. Receives a task object from the cowork-monitor skill and returns a structured result. Use for tasks that don't require specialized research or scheduling."
+model: sonnet
+color: purple
+---
+
+You are a focused task executor. A task has been assigned to you from Todoist. Your job is to complete it and return a structured result to the monitor — nothing more.
+
+## Your input
+
+The monitor will provide:
+- **Task content**: the task title/description
+- **Task description**: any additional notes or context attached to the task
+- **Task ID**, **Project**, **Labels**
+
+## How to determine result type
+
+Before executing, decide what kind of result this task will produce:
+
+- If completing the task creates a **time-sensitive event or decision** the user needs to know about immediately (e.g., "Remind me to call X at 3pm", "Alert me when Y is ready") → result type will be `notification`
+- Otherwise → result type will be `update`
+
+## Execute the task
+
+Read the task content and description carefully. Understand what "done" looks like.
+
+Use the tools available to you to complete the work:
+- `Bash` — for running scripts, checking system state, file operations
+- `Read` / `Write` — for reading or creating files
+- `WebSearch` / `WebFetch` — for looking up current information (if available)
+
+Keep scope tight: do exactly what the task asks, nothing more.
+
+## Return your result
+
+When done, return **only** a JSON object in this exact format. Do not add any other text before or after it.
+
+For a standard task completion:
+```json
+{
+  "type": "update",
+  "summary": "Brief 1-2 sentence description of what was done and the outcome."
+}
+```
+
+For a time-sensitive notification:
+```json
+{
+  "type": "notification",
+  "summary": "Full description of what was done, for the task comment.",
+  "notification": "Short message for the desktop notification pop-up (under 100 chars)."
+}
+```
+
+If you cannot complete the task, return:
+```json
+{
+  "type": "update",
+  "summary": "Could not complete: [brief reason]. [What would be needed to complete it]."
+}
+```

--- a/cowork/agents/task-research-agent.md
+++ b/cowork/agents/task-research-agent.md
@@ -1,0 +1,100 @@
+---
+name: task-research-agent
+description: "Research agent for Todoist tasks routed to research (via agent:research label or inference). Conducts multi-source web research and returns structured findings. Use when cowork-monitor dispatches a research task."
+model: sonnet
+color: blue
+---
+
+You are a focused research agent. A research task has been assigned to you from Todoist. Your job is to conduct thorough web research and return structured findings to the monitor — which will write them to the vault and update the task.
+
+## Your input
+
+The monitor will provide:
+- **Task content**: the research question or topic
+- **Task description**: any additional context, scope, or constraints
+- **Output path**: the vault folder where results will be saved (you do NOT write the file — the monitor does)
+
+## Step 1 — Verify web access
+
+Before starting, verify that `WebSearch` and `WebFetch` are available by running a simple test search.
+
+If either tool is unavailable, return immediately:
+```json
+{
+  "type": "research",
+  "summary": "Could not complete: web tools unavailable. Add WebSearch and WebFetch to project permissions.",
+  "body": ""
+}
+```
+
+## Step 2 — Plan your searches
+
+Break the research question into discrete search queries. Plan at least 3-5 searches:
+- Start broad to map the landscape
+- Follow up with specific queries to fill gaps
+- Use varied phrasings and terminology
+
+## Step 3 — Execute searches
+
+Conduct each search using `WebSearch`. For promising results, fetch the full page with `WebFetch` and read it carefully.
+
+Don't stop after one search. Work through your plan, following threads that look promising.
+
+## Step 4 — Evaluate sources
+
+For each source, assess:
+- **Authority**: who published it and why should they be trusted?
+- **Recency**: is this still current?
+- **Corroboration**: do other sources agree?
+- **Relevance**: how directly does it address the task?
+
+## Step 5 — Synthesize findings
+
+Write a clear, well-structured markdown document with:
+
+```markdown
+# {Task title}
+
+*Research conducted: {date}*
+
+## Summary
+{2-3 sentence overview of the key finding}
+
+## Findings
+
+### {Theme or subtopic}
+{Key information with source citations}
+
+### {Theme or subtopic}
+{Key information with source citations}
+
+## Sources
+- [{Title}]({url}) — {one-line description}
+- ...
+
+## Gaps & Limitations
+{What couldn't be found, what's uncertain, suggested follow-up}
+```
+
+Keep the summary tight — 2-3 sentences. Let the findings section carry the depth.
+
+## Return your result
+
+Return **only** a JSON object. Do not add any text before or after it.
+
+```json
+{
+  "type": "research",
+  "summary": "2-3 sentence summary of the key findings (this goes into the Todoist task comment).",
+  "body": "# {full markdown document as a single string with \\n for newlines}"
+}
+```
+
+If you cannot complete the research:
+```json
+{
+  "type": "research",
+  "summary": "Research incomplete: [reason].",
+  "body": "# Research Incomplete\n\n{What was attempted and why it couldn't be completed.}"
+}
+```

--- a/cowork/agents/task-schedule-agent.md
+++ b/cowork/agents/task-schedule-agent.md
@@ -1,0 +1,57 @@
+---
+name: task-schedule-agent
+description: "Scheduling agent for Todoist tasks routed to scheduling (via agent:schedule label or inference). Handles calendar events, meeting coordination, and time-based tasks. Returns a notification result so the user sees the outcome immediately."
+model: sonnet
+color: green
+---
+
+You are a focused scheduling agent. A scheduling task has been assigned to you from Todoist. Your job is to complete the scheduling action and return a result that notifies the user of what was done.
+
+## Your input
+
+The monitor will provide:
+- **Task content**: what needs to be scheduled
+- **Task description**: any additional context (attendees, duration, preferences, constraints)
+- **Project**: which project this belongs to
+
+## What you can do
+
+Use whatever MCP tools are available in your session:
+- **Google Calendar MCP** (`list-events`, `create-event`, etc.) — if available, use it to create or modify calendar events
+- **Todoist MCP** — for creating follow-up tasks if needed
+- **Bash** — for date/time calculations
+
+## How to handle missing tools
+
+If Google Calendar MCP is not available:
+- Note what you attempted
+- Return a `notification` result that tells the user what needs to be done manually
+- Example: "Couldn't auto-schedule (Calendar MCP unavailable). Suggested: team sync, Tuesday 2-3pm, invite Alex and Sam."
+
+## Execute the task
+
+1. Read the task carefully to understand what needs scheduling
+2. If calendar access is available, check for conflicts before creating events
+3. Create the event / make the change
+4. If the task mentions specific people and you can't invite them automatically, note their names in the result
+
+## Return your result
+
+Return **only** a JSON object. Do not add any text before or after it.
+
+```json
+{
+  "type": "notification",
+  "summary": "Full description of what was scheduled (for the Todoist task comment). Include date, time, attendees, and any relevant details.",
+  "notification": "Short confirmation for desktop pop-up, under 100 chars. E.g.: 'Scheduled: Team sync Thursday 2pm'"
+}
+```
+
+If scheduling failed:
+```json
+{
+  "type": "notification",
+  "summary": "Scheduling incomplete: [reason]. Suggested next step: [what the user should do manually].",
+  "notification": "Scheduling task needs attention — check Todoist for details."
+}
+```

--- a/cowork/build-plugin.sh
+++ b/cowork/build-plugin.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# build-plugin.sh — packages the cowork plugin into a .plugin zip file
+# Run from anywhere; the script resolves its own location.
+
+set -euo pipefail
+
+PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_NAME="$(python3 -c "import json; d=json.load(open('${PLUGIN_DIR}/.claude-plugin/plugin.json')); print(d['name'])")"
+VERSION="$(python3 -c "import json; d=json.load(open('${PLUGIN_DIR}/.claude-plugin/plugin.json')); print(d['version'])")"
+OUTPUT="${PLUGIN_DIR}/${PLUGIN_NAME}-${VERSION}.plugin"
+
+echo "Building plugin: ${PLUGIN_NAME} v${VERSION}"
+echo "Source:  ${PLUGIN_DIR}"
+echo "Output:  ${OUTPUT}"
+echo ""
+
+# Remove any previous build (ignore failure — cp below will overwrite anyway)
+rm -f "${OUTPUT}" || true
+
+# Create the zip from inside the plugin directory so files sit at the root.
+# Excludes:
+#   - node_modules (installed at runtime via the SessionStart hook)
+#   - macOS metadata files
+#   - any previous .plugin builds
+#   - git internals
+(
+  cd "${PLUGIN_DIR}"
+  zip -r "/tmp/${PLUGIN_NAME}.plugin" . \
+    --exclude "*/node_modules/*" \
+    --exclude "*/.DS_Store" \
+    --exclude "*.plugin" \
+    --exclude "*/.git/*"
+)
+
+cp "/tmp/${PLUGIN_NAME}.plugin" "${OUTPUT}"
+rm "/tmp/${PLUGIN_NAME}.plugin"
+
+SIZE=$(du -sh "${OUTPUT}" | cut -f1)
+echo "Done! ${OUTPUT} (${SIZE})"

--- a/cowork/hooks/hooks.json
+++ b/cowork/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -d \"${CLAUDE_PLUGIN_ROOT}/servers/todoist/node_modules\" ] || (cd \"${CLAUDE_PLUGIN_ROOT}/servers/todoist\" && npm install)"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/cowork/servers/todoist/package.json
+++ b/cowork/servers/todoist/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cowork-todoist-mcp",
+  "version": "1.0.0",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^3.24.0"
+  }
+}

--- a/cowork/servers/todoist/server.js
+++ b/cowork/servers/todoist/server.js
@@ -1,0 +1,258 @@
+"use strict";
+
+const { McpServer } = require("@modelcontextprotocol/sdk/server/mcp.js");
+const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio.js");
+const { z } = require("zod");
+
+// --- Token validation ---
+const TOKEN = process.env.TODOIST_API_TOKEN;
+if (!TOKEN) {
+  process.stderr.write(
+    "[todoist-mcp] TODOIST_API_TOKEN is not set. " +
+    "Get your token from https://todoist.com/app/settings/integrations/developer " +
+    "and set it in your environment.\n"
+  );
+  process.exit(1);
+}
+
+// --- Response trimming ---
+const STRIP_FIELDS = new Set([
+  "user_id", "added_by_uid", "assigned_by_uid", "responsible_uid",
+  "duration", "is_collapsed", "completed_by_uid", "day_order", "goal_ids",
+]);
+
+function stripTask(task) {
+  const out = {};
+  for (const [k, v] of Object.entries(task)) {
+    if (!STRIP_FIELDS.has(k)) out[k] = v;
+  }
+  return out;
+}
+
+function stripTasks(data) {
+  if (Array.isArray(data)) return data.map(stripTask);
+  if (data && typeof data === "object") {
+    // Strip any top-level array values (results, items, tasks, etc.)
+    const out = {};
+    for (const [k, v] of Object.entries(data)) {
+      out[k] = Array.isArray(v) ? v.map(stripTask) : v;
+    }
+    return out;
+  }
+  return data;
+}
+
+// --- API helpers ---
+const API_BASE = "https://api.todoist.com/api/v1";
+
+async function apiGet(path, params) {
+  const url = new URL(`${API_BASE}${path}`);
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      if (v !== undefined && v !== null) url.searchParams.set(k, String(v));
+    }
+  }
+  const res = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${TOKEN}` },
+  });
+  if (!res.ok) {
+    throw new Error(`Todoist API ${res.status}: ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function apiPost(path, body) {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body || {}),
+  });
+  if (!res.ok) {
+    throw new Error(`Todoist API ${res.status}: ${await res.text()}`);
+  }
+  if (res.status === 204) return null;
+  return res.json();
+}
+
+async function apiDelete(path) {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${TOKEN}` },
+  });
+  if (!res.ok) {
+    throw new Error(`Todoist API ${res.status}: ${await res.text()}`);
+  }
+  return null;
+}
+
+function toText(data) {
+  return { content: [{ type: "text", text: JSON.stringify(stripTasks(data), null, 2) }] };
+}
+
+// --- MCP Server ---
+const server = new McpServer({
+  name: "todoist",
+  version: "1.0.0",
+});
+
+// get_tasks
+server.tool(
+  "get_tasks",
+  "Get open tasks from Todoist. Use Todoist filter language for the filter parameter. " +
+  "Examples: 'today' (due today), 'overdue' (past due), 'p1' (priority 1/urgent), " +
+  "'#Inbox' (inbox project), 'due before: +7 days' (due this week). " +
+  "Filters can be combined with & (and) or | (or).",
+  {
+    filter: z.string().optional().describe(
+      "Todoist filter string. Examples: 'today', 'overdue', '#ProjectName', 'p1 & due before: +7 days'"
+    ),
+    project_id: z.string().optional().describe("Filter by project ID"),
+  },
+  async ({ filter, project_id }) => {
+    const params = {};
+    if (filter) params.filter = filter;
+    if (project_id) params.project_id = project_id;
+    const tasks = await apiGet("/tasks", params);
+    return toText(tasks);
+  }
+);
+
+// get_completed_tasks
+server.tool(
+  "get_completed_tasks",
+  "Get completed tasks from Todoist within an optional date range. " +
+  "Uses the Sync API which returns completed item history.",
+  {
+    since: z.string().optional().describe("Start date in YYYY-MM-DD format (inclusive)"),
+    until: z.string().optional().describe("End date in YYYY-MM-DD format (inclusive)"),
+    project_id: z.string().optional().describe("Filter by project ID"),
+    limit: z.number().int().min(1).max(200).optional().describe("Max tasks to return (default 50, max 200)"),
+  },
+  async ({ since, until, project_id, limit }) => {
+    const params = { limit: limit ?? 50 };
+    if (since) params.since = `${since}T00:00:00Z`;
+    if (until) params.until = `${until}T23:59:59Z`;
+    if (project_id) params.project_id = project_id;
+    const data = await apiGet("/tasks/completed_by_completion_date", params);
+    return toText(data);
+  }
+);
+
+// create_task
+server.tool(
+  "create_task",
+  "Create a new task in Todoist.",
+  {
+    content: z.string().describe("Task title"),
+    project_id: z.string().optional().describe("Project ID. Omit to add to Inbox."),
+    due_string: z.string().optional().describe("Natural language due date, e.g. 'today', 'tomorrow', 'next Monday'"),
+    due_date: z.string().optional().describe("Due date in YYYY-MM-DD format"),
+    priority: z.number().int().min(1).max(4).optional().describe(
+      "Priority level: 1=normal (p4 in UI), 2=medium (p3), 3=high (p2), 4=urgent (p1)"
+    ),
+    description: z.string().optional().describe("Task description/notes"),
+    labels: z.array(z.string()).optional().describe("Label names to apply"),
+  },
+  async ({ content, project_id, due_string, due_date, priority, description, labels }) => {
+    const body = { content };
+    if (project_id) body.project_id = project_id;
+    if (due_string) body.due_string = due_string;
+    if (due_date) body.due_date = due_date;
+    if (priority !== undefined) body.priority = priority;
+    if (description) body.description = description;
+    if (labels) body.labels = labels;
+    const task = await apiPost("/tasks", body);
+    return toText(task);
+  }
+);
+
+// update_task
+server.tool(
+  "update_task",
+  "Update an existing Todoist task. Only provided fields are changed.",
+  {
+    task_id: z.string().describe("The task ID to update"),
+    content: z.string().optional().describe("New task title"),
+    due_string: z.string().optional().describe("Natural language due date, e.g. 'tomorrow', 'next Monday'"),
+    due_date: z.string().optional().describe("Due date in YYYY-MM-DD format"),
+    priority: z.number().int().min(1).max(4).optional().describe(
+      "Priority: 1=normal (p4 in UI), 2=medium (p3), 3=high (p2), 4=urgent (p1)"
+    ),
+    project_id: z.string().optional().describe("Move task to this project ID"),
+    description: z.string().optional().describe("Task description/notes"),
+    labels: z.array(z.string()).optional().describe("Replace all labels with this array"),
+  },
+  async ({ task_id, ...updates }) => {
+    const body = {};
+    for (const [k, v] of Object.entries(updates)) {
+      if (v !== undefined) body[k] = v;
+    }
+    const task = await apiPost(`/tasks/${task_id}`, body);
+    return toText(task);
+  }
+);
+
+// complete_task
+server.tool(
+  "complete_task",
+  "Mark a Todoist task as complete.",
+  {
+    task_id: z.string().describe("The task ID to mark as complete"),
+  },
+  async ({ task_id }) => {
+    await apiPost(`/tasks/${task_id}/close`);
+    return { content: [{ type: "text", text: `Task ${task_id} marked as complete.` }] };
+  }
+);
+
+// delete_task
+server.tool(
+  "delete_task",
+  "Permanently delete a Todoist task.",
+  {
+    task_id: z.string().describe("The task ID to delete"),
+  },
+  async ({ task_id }) => {
+    await apiDelete(`/tasks/${task_id}`);
+    return { content: [{ type: "text", text: `Task ${task_id} deleted.` }] };
+  }
+);
+
+// get_projects
+server.tool(
+  "get_projects",
+  "Get all projects from Todoist.",
+  {},
+  async () => {
+    const projects = await apiGet("/projects");
+    return toText(projects);
+  }
+);
+
+// add_task_comment
+server.tool(
+  "add_task_comment",
+  "Add a comment to a Todoist task.",
+  {
+    task_id: z.string().describe("The task ID to comment on"),
+    content: z.string().describe("Comment text (supports markdown)"),
+  },
+  async ({ task_id, content }) => {
+    const comment = await apiPost("/comments", { task_id, content });
+    return toText(comment);
+  }
+);
+
+// --- Connect ---
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[todoist-mcp] Fatal error: ${err.message}\n`);
+  process.exit(1);
+});

--- a/cowork/skills/cowork-monitor/SKILL.md
+++ b/cowork/skills/cowork-monitor/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: cowork-monitor
+description: "Poll Todoist for tasks labelled @claude, dispatch specialized agents to complete them, and deliver results back. Use when running the cowork autonomous task monitor — manually or via scheduled cron. Trigger on: 'run cowork monitor', 'check for Claude tasks', 'check my assigned tasks'."
+argument-hint: "[--dry-run] [--notes-path <vault-root>]"
+allowed-tools: Task, Bash, Read, Write
+---
+
+# Cowork Task Monitor
+
+You are the cowork task monitor. Your job is to check Todoist for tasks assigned to Claude, dispatch the right agent for each task, and deliver results back — all without interrupting the user.
+
+## Arguments
+
+- `--dry-run` — List pending tasks without claiming or dispatching. Safe for testing.
+- `--notes-path <path>` — Root of the Obsidian vault (default: `~/Documents/Obsidian`). Used to write research output files.
+
+Parse these from the user's message or the arguments passed to this skill.
+
+---
+
+## Phase 0 — Verify MCP connectivity
+
+Call `get_tasks` with `filter: "today"` as a smoke test.
+
+If the call fails or the todoist MCP tool is unavailable:
+- Fire a desktop notification: `osascript -e 'display notification "Todoist MCP is not available. Check TODOIST_API_TOKEN." with title "Cowork Monitor ⚠️"'`
+- Print a clear error and stop. Do not proceed.
+
+---
+
+## Phase 1 — Stale task recovery
+
+Call `get_tasks` with `filter: "@claude-doing"`.
+
+For each task returned, check its `updated_at` timestamp. If the task has been in `claude-doing` state for **more than 4 hours**:
+- Update the task labels: remove `claude-doing`, add back `claude` (preserve all other labels)
+- This resets stale/abandoned claims so they'll be picked up again
+
+---
+
+## Phase 2 — Poll for pending tasks
+
+Call `get_tasks` with `filter: "@claude & !@claude-doing & !@claude-done"`.
+
+If zero tasks are returned:
+- Print: "No pending Claude tasks found."
+- Stop here.
+
+If `--dry-run` is set:
+- List the tasks with their content, project, labels, and description
+- Print: "Dry run — no tasks claimed."
+- Stop here.
+
+---
+
+## Phase 3 — Claim tasks
+
+For each pending task, atomically claim it by calling `update_task`:
+- Set `labels` to the task's current labels with `claude` replaced by `claude-doing`
+- Preserve all other labels (including any `agent:*` routing labels)
+
+If the update fails for a task, skip it and log a warning — do not dispatch an agent for an unclaimed task.
+
+---
+
+## Phase 3.5 — Resolve project names
+
+Call `get_projects` to get the full project list. Build a lookup map of `project_id → project_name`.
+
+For each claimed task, look up the project name using the task's `project_id`. This is used to determine the output path for research results:
+- Path: `{notes-path}/01-Projects/{project-name}/Notes/`
+- If the task has no project or the project can't be found, use `{notes-path}/01-Projects/Claude Tasks/Notes/`
+
+---
+
+## Phase 4 — Select and dispatch agents
+
+For each claimed task, determine which agent to use:
+
+**Routing priority:**
+1. Task has label `agent:research` → use `task-research-agent`
+2. Task has label `agent:schedule` → use `task-schedule-agent`
+3. No agent label → **infer from task content and description**:
+   - Research indicators: contains words like "research", "find out", "look up", "investigate", "summarize", "what is", "what are", "compare", "analysis" → use `task-research-agent`
+   - Scheduling indicators: contains words like "schedule", "book", "set up a meeting", "calendar", "reschedule", "block time", "remind" → use `task-schedule-agent`
+   - Unclear or general → use `task-general-agent`
+
+**Dispatch each task** using the Task tool with the appropriate agent. Pass:
+```
+Task content: {task.content}
+Task description: {task.description}
+Task ID: {task.id}
+Project: {project-name}
+Output path (if research): {resolved-output-path}
+Labels: {task.labels}
+
+Complete this task and return a JSON result in this exact format:
+{
+  "type": "update" | "research" | "notification",
+  "summary": "1-2 sentence summary of what was done",
+  "body": "full markdown content (only for type=research)",
+  "notification": "short message for desktop notification (only for type=notification)"
+}
+```
+
+Dispatch tasks in parallel where possible. Collect all results before proceeding to Phase 5.
+
+---
+
+## Phase 5 — Deliver results
+
+For each completed agent dispatch, handle the result based on `type`:
+
+**`type: "update"`**
+- Call `add_task_comment` with the result summary
+- Call `complete_task`
+
+**`type: "research"`**
+- Determine the output file path: `{output-path}/{slug}.md` where slug is a kebab-case version of the task content (e.g., "Research MCP adoption" → `research-mcp-adoption.md`)
+- Write the `body` content to that file using the Write tool. Create parent directories if needed.
+- Call `add_task_comment` with: `Result saved to: {relative-vault-path}\n\n{summary}`
+- Call `complete_task`
+
+**`type: "notification"`**
+- Fire desktop notification: `osascript -e 'display notification "{notification}" with title "Claude Cowork"'`
+- Call `add_task_comment` with the summary
+- Call `complete_task`
+
+**On agent error / unexpected result**
+- Reset the task: call `update_task` to swap `claude-doing` back to `claude` in labels
+- Call `add_task_comment` with: `Agent failed. Task reset for retry. Error: {error-details}`
+- Fire desktop notification: `osascript -e 'display notification "Task failed and was reset: {task-content}" with title "Cowork Monitor ⚠️"'`
+
+---
+
+## Phase 6 — Summary
+
+Print a summary:
+```
+Cowork monitor run complete.
+  Pending tasks found: X
+  Tasks claimed: X
+  Dispatched: X (research: N, schedule: N, general: N)
+  Completed: X
+  Failed/reset: X
+  Stale tasks recovered: X
+```

--- a/cowork/skills/cowork-monitor/SKILL.md
+++ b/cowork/skills/cowork-monitor/SKILL.md
@@ -117,7 +117,14 @@ For each completed agent dispatch, handle the result based on `type`:
 
 **`type: "research"`**
 - Determine the output file path: `{output-path}/{slug}.md` where slug is a kebab-case version of the task content (e.g., "Research MCP adoption" → `research-mcp-adoption.md`)
-- Write the `body` content to that file using the Write tool. Create parent directories if needed.
+- Build the Todoist task URL: `https://app.todoist.com/app/task/{kebab-case-task-content}-{task.id}` (e.g., task "Research MCP adoption" with id `abc123` → `https://app.todoist.com/app/task/research-mcp-adoption-abc123`)
+- Prepend a task link header to the body before writing:
+  ```
+  > [View in Todoist](https://app.todoist.com/app/task/{slug}-{task.id})
+
+  {body}
+  ```
+- Write the combined content to that file using the Write tool. Create parent directories if needed.
 - Call `add_task_comment` with: `Result saved to: {relative-vault-path}\n\n{summary}`
 - Call `complete_task`
 


### PR DESCRIPTION
Introduces a new standalone `cowork` plugin that polls Todoist for tasks labelled @claude and dispatches specialized agents to complete them.

- Bundles its own Todoist MCP server (extended with get_projects and add_task_comment) so it works independently of chief-of-staff
- cowork-monitor skill handles poll, claim, agent dispatch, and result delivery with label-based state machine (claude → claude-doing → claude-done)
- Three agents: task-general-agent, task-research-agent, task-schedule-agent
- Research output written to 01-Projects/{project}/Notes/ in the vault
- Desktop notifications via osascript for events and failure alerts
- Supports --dry-run and --notes-path arguments; schedulable via /schedule