### PR TITLE
Add aor-review and project-monitor skills, overhaul wrap-week

### DIFF
--- a/chief-of-staff/README.md
+++ b/chief-of-staff/README.md
@@ -1,6 +1,6 @@
 # Chief of Staff
 
-AI-enabled executive assistant for Claude Code. Seven skills that work together to keep you deliberate about your time, on top of your projects, and moving purposefully through each day and week.
+AI-enabled executive assistant for Claude Code. Ten skills that work together to keep you deliberate about your time, on top of your projects, and moving purposefully through each day and week.
 
 **The problem it solves:** Knowledge work is full of context-switching, accumulating commitments, and slow entropy — tasks slip, projects drift, and weeks end without a clear sense of what moved forward. Chief of Staff gives you a structured rhythm: open the week with intention, start each day with a real briefing, close the day cleanly, review the week honestly, and keep your projects from becoming a graveyard of half-finished plans.
 
@@ -11,16 +11,19 @@ AI-enabled executive assistant for Claude Code. Seven skills that work together 
 The skills form an integrated operating cycle:
 
 ```
-Monday morning     → /start-week    Set 2–3 priorities, surface project deadlines, create the weekly file
-Each morning       → /start-day     Briefing: calendar, priority emails, weekly priorities, tasks, meeting notes
-Throughout week    → /project-index Quick project status lookup (also called automatically by other skills)
-Throughout week    → /project-planner  Turn a new initiative into a structured, phased plan
-Throughout week    → /project-tracker  Lightweight tracking for projects owned by your team
-Each evening       → /finish-day    Close out: email triage, brain dump, reschedule, prep tomorrow's notes
-Friday afternoon   → /wrap-week     Narrative recap fills in the weekly file /start-week created
+Monday morning     → /start-week        Set 2–3 priorities, surface project deadlines, create the weekly file
+Each morning       → /start-day         Briefing: calendar, priority emails, weekly priorities, tasks, meeting notes
+Throughout week    → /project-index     Quick project status lookup (also called automatically by other skills)
+Throughout week    → /new-project       Create a project folder + Todoist project, then kick off planner or tracker
+Throughout week    → /project-planner   Turn a new initiative into a structured, phased plan
+Throughout week    → /project-tracker   Lightweight tracking for projects owned by your team
+Throughout week    → /project-monitor   Compare project plans against Todoist — surface gaps, stalls, deadlines
+Throughout week    → /aor-review        Review area health, surface backlog patterns, spin up projects as needed
+Each evening       → /finish-day        Close out: email triage, brain dump, reschedule, prep tomorrow's notes
+Friday afternoon   → /wrap-week         Recap this week, plan next week with priorities, create next week's file
 ```
 
-The daily rhythm is the foundation: `/finish-day` each evening seeds the context that makes `/start-day` valuable the next morning. The weekly rhythm gives that daily context meaning — priorities set on Monday shape how you rank tasks and allocate focus all week. The project skills connect the big picture (multi-week initiatives) to the daily and weekly ground level.
+The daily rhythm is the foundation: `/finish-day` each evening seeds the context that makes `/start-day` valuable the next morning. The weekly rhythm gives that daily context meaning — priorities set on Monday shape how you rank tasks and allocate focus all week. `/wrap-week` now creates next week's planning file during the Friday session, so you start Monday already oriented. The project skills keep the big picture (multi-week initiatives) connected to the daily and weekly ground level — `/project-monitor` and `/aor-review` run automatically inside `/wrap-week` but can also be run anytime independently.
 
 ---
 
@@ -74,7 +77,25 @@ If Gmail MCP is unavailable, both skills degrade gracefully and note that email 
 
 ## Obsidian Vault Setup
 
-The chief of staff assumes a particular structure to the Obsidian vault.  These can be overridden the default paths with arguments if your vault uses different folder names:
+The chief of staff assumes a particular structure to the Obsidian vault based on Tiago Forte's PARA system. Default paths can be overridden two ways: a `CLAUDE.md` config block in the vault root (applied every run), or per-invocation arguments (highest precedence).
+
+### CLAUDE.md Configuration
+
+Add a **Chief of Staff** section to your vault's `CLAUDE.md` to set defaults without passing arguments every time:
+
+```markdown
+## Chief of Staff
+- projects-path: Projects
+- daily-notes-path: Journal/Daily
+- notes-path: Meetings
+- weekly-recaps-path: Reviews/Weekly
+- areas-path: Areas
+```
+
+Any value set here acts as the default for all skills that use that path. Per-invocation arguments still override CLAUDE.md values.
+
+### Per-invocation Overrides
+
 ```
 /start-day --daily-notes-path "Journal/Daily" --notes-path "Meetings"
 /wrap-week --weekly-recaps-path "Reviews/Weekly"
@@ -117,7 +138,7 @@ Enable the **Daily Notes** core plugin in Obsidian (Settings → Core Plugins �
 The `Notes/` is where meeting notes are maintained. Files in this folder are never modified except to append new date sections for recurring meetings by `/finish-day`. No content is moved or duplicated.
 
 ### Projects
-Every projects has its own folder with at least a `PLAN.md` file that contains the plan overview.  Notes specific to the project can be contained within a `Notes/` folder in the project.  Projects that are of interest but not being directly led by the user go into sub-folders within `Watched/`.
+Every projects has its own folder with at least a `PLAN.md` file that contains the plan overview.  Notes specific to the project can be contained within a `Notes/` folder in the project.  Projects that are of interest but not being directly led by the user go into sub-folders within `Watched/`.  Projects are assumed to have a Todoist project named the same.  The `/new-project` skill will create a project folder, Todoist project and kick off the appropriate skill to generate the right PLAN.md file.
 
 ---
 
@@ -135,15 +156,18 @@ If connected with an MCP server, processing can be automatically triggered by pa
 
 ## Skills Reference
 
-| Skill              | Description                                                                                                    | When to use                                            |
-| ------------------ | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| `/start-week`      | Set 2–3 weekly priorities, review projects for deadlines, create weekly planning file                          | Monday morning                                         |
-| `/start-day`       | Morning briefing with priority emails, weekly priorities, calendar, tasks, and meeting notes                   | Each morning before starting work                      |
-| `/finish-day`      | Day close-out: priority email triage, brain dump, reschedule tasks, transcript reminder, prep tomorrow's notes | Each evening before logging off                        |
-| `/wrap-week`       | Mon–Sun narrative recap saved to Obsidian, fills in the weekly planning file, reviews areas of responsibility  | Friday afternoon or Sunday evening                     |
-| `/project-index`   | Fast lookup of all active projects — names, descriptions, areas, due dates from PLAN.md frontmatter            | On demand, or automatically by other skills            |
-| `/project-planner` | Turn a new initiative into a structured, phased plan with objectives, tasks, and exit criteria                 | When starting or updating a project you own            |
-| `/project-tracker` | Lightweight tracking doc for a project owned by someone on your team                                           | When you need to follow a report's project during 1:1s |
+| Skill               | Description                                                                                                     | When to use                                            |
+| ------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `/start-week`       | Set 2–3 weekly priorities, review projects for deadlines, create weekly planning file                           | Monday morning                                         |
+| `/start-day`        | Morning briefing with priority emails, weekly priorities, calendar, tasks, and meeting notes                    | Each morning before starting work                      |
+| `/finish-day`       | Day close-out: priority email triage, brain dump, reschedule tasks, transcript reminder, prep tomorrow's notes  | Each evening before logging off                        |
+| `/wrap-week`        | Recap this week (1/3), plan next week with 2–3 priorities (2/3), creates next week's planning file              | Friday afternoon or Sunday evening                     |
+| `/aor-review`       | Review each Area of Responsibility — open task counts, age flags, suggest spinning up projects where warranted  | On demand, or automatically (silently) by /wrap-week   |
+| `/project-monitor`  | Compare active project plans against Todoist — surface stalls, task gaps, and approaching deadlines             | On demand, or automatically (silently) by /wrap-week   |
+| `/project-index`    | Fast lookup of all active projects — names, descriptions, areas, due dates from PLAN.md frontmatter             | On demand, or automatically by other skills            |
+| `/new-project`      | Create an Obsidian project folder and matching Todoist project, then hand off to planner or tracker             | Whenever you're starting a new project                 |
+| `/project-planner`  | Turn a new initiative into a structured, phased plan with objectives, tasks, and exit criteria                  | When starting or updating a project you own            |
+| `/project-tracker`  | Lightweight tracking doc for a project owned by someone on your team                                            | When you need to follow a report's project during 1:1s |
 
 ### Arguments
 
@@ -163,9 +187,21 @@ If connected with an MCP server, processing can be automatically triggered by pa
 - `--daily-notes-path <path>` — Override default daily notes folder
 - `--weekly-recaps-path <path>` — Override weekly recaps folder (default: `02-AreasOfResponsibility/Weekly Recaps`)
 - `--areas-path <path>` — Override areas of responsibility root folder (default: `02-AreasOfResponsibility`)
+- `--focus <text>` — Specify a theme or area to emphasize when setting next week's priorities
+
+**`/aor-review`**
+- `--areas-path <path>` — Override areas of responsibility root folder (default: `02-AreasOfResponsibility`)
+- `--summary` — Run in silent summary mode (no interaction, structured output only — used by `/wrap-week`)
+
+**`/project-monitor`**
+- `--projects-path <path>` — Override projects root folder (default: `01-Projects`)
+- `--summary` — Run in silent summary mode (no interaction, structured output only — used by `/wrap-week`)
 
 **`/project-index`**
 - No arguments — reads from `01-Projects/*/PLAN.md` in the current working directory
+
+**`/new-project`**
+- `--projects-path <path>` — Override projects root folder. Precedence: this argument > `CLAUDE.md` config > default (`01-Projects`)
 
 **`/project-planner`**
 - No arguments — begins an interview to scope and structure the project
@@ -192,3 +228,7 @@ If connected with an MCP server, processing can be automatically triggered by pa
 **Project descriptions are for machines.** The `description` field in each `PLAN.md` is read by the hook and injected as context into `/start-week` and other skills. Write it like a dense search snippet — system names, team names, the specific problem — so the index is useful for matching.
 
 **`/project-tracker` vs. `/project-planner`.** Tracker is for watching someone else's work (your reports, cross-functional partners). Planner is for structuring work you own. Don't use planner for observation — it'll create false accountability.
+
+**`/project-monitor` and `/aor-review` run inside `/wrap-week` automatically.** You don't need to run them separately on Fridays — wrap-week invokes both silently and uses their output to inform priority-setting. Run them independently mid-week when you want a focused check-in without going through the full wrap-week flow.
+
+**`/wrap-week` creates next week's file.** You'll start Monday with priorities and project context already written. `/start-week` is still useful if you want a more deliberate Monday planning session, but it's no longer required.

--- a/chief-of-staff/skills/aor-review/SKILL.md
+++ b/chief-of-staff/skills/aor-review/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: aor-review
+description: Reviews the health of each Area of Responsibility by checking open Todoist task counts, task age, and clustering patterns. Surfaces flags, suggests spinning up projects where warranted, and lets the user decide how to handle each area. Can be run standalone or invoked silently by /wrap-week in summary mode. Trigger when the user says "review my areas", "check my areas of responsibility", "AOR review", or invokes /aor-review. Must be run from the root of the Obsidian vault.
+---
+
+# AOR Review
+
+You are helping the user check in on their Areas of Responsibility (AORs) — the ongoing domains they own, distinct from time-bound projects. The goal is to surface areas that have accumulated work, identify where a dedicated project might make sense, and make sure nothing important is being neglected.
+
+This skill can run in two modes:
+
+- **Standalone** (default): Full interactive session — presents health signals, asks the user for decisions per area, and takes actions (schedule reviews, spin up projects).
+- **Summary mode** (`--summary`): Silent data-gathering only. Returns structured output for another skill (e.g., `/wrap-week`) to consume. No interactive prompts, no actions taken.
+
+## Arguments
+
+- `--areas-path <path>` — override areas of responsibility root folder (default: `02-AreasOfResponsibility`)
+- `--summary` — run in summary mode (no interaction, structured output only)
+
+## Vault Paths (relative to vault root)
+
+- Areas of responsibility: `02-AreasOfResponsibility/` (subfolders, excluding `Daily Notes`, `Weekly Recaps`, `Notes`)
+
+---
+
+## Phase 1: Discover Areas
+
+List the subfolders of the areas path (default: `02-AreasOfResponsibility/`). Exclude system folders: `Daily Notes`, `Weekly Recaps`, `Notes`. Each remaining subfolder is one AOR. Its folder name must match the corresponding Todoist project name exactly.
+
+If no subfolders are found (or the path doesn't exist):
+- **Standalone:** Tell the user no AOR folders were found and skip to closing.
+- **Summary mode:** Return `[]` and exit.
+
+---
+
+## Phase 2: Gather Context (run in parallel)
+
+For each AOR folder:
+
+- Read any `.md` files in that folder to understand the area's scope and objective
+- Call `find-tasks` filtered to the matching Todoist project name to fetch all open tasks, including due dates and creation dates
+
+---
+
+## Phase 3: Synthesize Health Per Area
+
+For each area, assess:
+
+**Metrics:**
+- Open task count
+- Age of the oldest open task (days since creation)
+- Whether any tasks are overdue or due this week
+
+**Themes:**
+- Brief synthesis of what kinds of work are queued (2–3 words per theme is enough)
+
+**Project readiness signal** — flag if ANY of the following:
+- ≥5 open tasks
+- Any task is >30 days old
+- Tasks appear to cluster around a specific deliverable or initiative
+
+When flagging, state the reason concisely: e.g., "5 tasks around improving CI/CD pipeline — this looks like a project."
+
+---
+
+## Phase 4: Present and Act
+
+### Summary mode (`--summary`)
+
+Return a structured list without any user interaction:
+
+```
+[Area Name] | open: X | oldest: Y days | health: ok/flagged | reason: [flag reason or "—"]
+```
+
+Exit after returning the list. No further interaction.
+
+---
+
+### Standalone mode
+
+For each area, present:
+
+```
+### [Area Name]
+Open tasks: X  |  Oldest: Y days old  [⚠️ if >30 days]
+Themes: [2–3 sentence synthesis of what's queued]
+[💡 Suggested: Consider spinning up a project — [reason]]  ← only if flagged
+```
+
+After presenting all areas, collect decisions. Ask the user to respond for each area:
+
+- **Looks good** — no action needed
+- **Schedule a review** → create a Todoist task in that project due next Monday: "Review [Area Name]"
+- **Spin up a project** → ask for project name → create project stub (see template below)
+
+Collect all decisions before executing. Batch all `add-task` calls together, then write any PLAN.md files.
+
+---
+
+## Project Stub Template
+
+When creating `01-Projects/<Name>/PLAN.md`:
+
+```markdown
+---
+name: <Project Name>
+description: <keyword-rich summary used for machine matching — include system names, team names, business domain, the specific problem and approach. Not a generic summary.>
+due_date: <YYYY-MM-DD — omit entirely if no hard deadline>
+area: <area-name>
+started: <today>
+tags: [project]
+---
+
+# <Project Name>
+
+## Overview
+
+<2–4 sentence narrative: why this project exists, who's involved, what's driving it, and any important background. Dense enough to get back up to speed before a meeting.>
+
+## Tasks
+
+- [ ] <!-- Relevant open tasks from the [Area Name] Todoist project -->
+
+## Updates
+
+<!-- Filled in over time as the project progresses -->
+```
+
+After creating the stub, tell the user: "Run `/project-planner` on this project to build out the full plan with phases, objectives, and exit criteria."
+
+---
+
+## Closing (standalone only)
+
+Summarize actions taken:
+
+```
+AOR review complete.
+- [N] areas reviewed
+- [X] look good
+- [Y] reviews scheduled
+- [Z] project(s) created: [names]
+```
+
+If any projects were created, remind the user to run `/project-planner` to flesh them out.

--- a/chief-of-staff/skills/finish-day/SKILL.md
+++ b/chief-of-staff/skills/finish-day/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finish-day
-description: End-of-day wrap-up — reviews completed and incomplete Todoist tasks, triages the Todoist inbox, recaps today's calendar, reminds about transcripts (with optional n8n MCP trigger), reschedules incomplete tasks, preps tomorrow's meeting notes in Obsidian, and updates today's daily note with a day summary. Trigger when the user says "finish my day", "wrap up today", "end of day", or invokes /finish-day. Must be run from the root of the Obsidian vault.
+description: End-of-day wrap-up — reviews completed and incomplete Todoist tasks, triages the Todoist inbox, recaps today's calendar and Slack activity, reminds about transcripts (with optional n8n MCP trigger), reschedules incomplete tasks, preps tomorrow's meeting notes in Obsidian, and updates today's daily note with a day summary. Trigger when the user says "finish my day", "wrap up today", "end of day", or invokes /finish-day. Must be run from the root of the Obsidian vault.
 ---
 
 # Finish Day
@@ -55,6 +55,13 @@ label:Priority/p1 OR label:Priority/p2
 
 (Adjust the exact tool name to match your Gmail MCP server.) For each email capture: subject, sender, date received, and any visible snippet or body. If unavailable, skip and note it.
 
+**Slack — today's activity:** Call the Slack MCP server to retrieve messages from today. Fetch in this order:
+1. **Direct messages** — conversations you sent or received today
+2. **Mentions** — any messages where you were @-mentioned in any channel
+3. **Active channels** — messages you posted in today
+
+For each Slack item capture: channel or DM partner, timestamp, and a brief summary of the content. Focus on messages that indicate decisions made, commitments given, or action items promised. If the Slack MCP is unavailable, skip and note it.
+
 If any MCP server is unavailable, tell the user which one and continue with whatever data is accessible.
 
 ## Phase 2: Surface Priority Emails
@@ -100,6 +107,16 @@ Present a brief, honest review:
 
 - Completed Todoist tasks (with project)
 - Calendar events that happened today
+
+**Slack Activity** (only if Slack data was retrieved)
+
+Summarize today's Slack conversations to help jog memory. Group by type:
+
+- *Decisions made* — threads or DMs where a clear decision or direction was agreed upon
+- *Commitments given* — things you said you'd do, or that someone said they'd do for you
+- *Notable conversations* — anything substantive that doesn't fit the above
+
+Keep each entry to one line. If a Slack item looks like it should become a Todoist task (a commitment with no follow-up captured yet), flag it: "This looks like an uncaptured action item — add to inbox?"
 
 **Still Open**
 

--- a/chief-of-staff/skills/finish-day/templates/adhoc-meeting.md
+++ b/chief-of-staff/skills/finish-day/templates/adhoc-meeting.md
@@ -1,18 +1,11 @@
 ---
+MeetingDate: <DATE>
+Type: Meeting
 tags: [meeting, ad-hoc]
 ---
 
-# <Meeting Name> — <DATE>
+## Preamble
 
-**Objective:** <!-- Why this meeting exists -->
-**Attendees:**
+## My Topics
 
-## Notes
-
-## Decisions
-
-## Action Items
-
-- [ ]
-
-## Follow-up
+## Their Topics

--- a/chief-of-staff/skills/finish-day/templates/recurring-meeting.md
+++ b/chief-of-staff/skills/finish-day/templates/recurring-meeting.md
@@ -1,20 +1,13 @@
 ---
+Type: 1:1
+MeetingDate: <DATE>
 tags: [meeting, recurring]
 ---
 
-# <Meeting Name>
-
-<!-- One-line description of the standing purpose of this meeting -->
-
 ## <DATE>
 
-### Agenda
+### My Topics
 
-### Notes
+### Their Topics
 
-### Action Items
-
-- [ ]
-
-### Carried Forward
-<!-- Items from last session that weren't resolved -->
+### For Next Time

--- a/chief-of-staff/skills/new-project/SKILL.md
+++ b/chief-of-staff/skills/new-project/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: new-project
+description: Create a new project — Obsidian folder and PLAN.md (via /project-planner for your own projects, or /project-tracker for team member projects), plus a matching Todoist project in the right location. Trigger on phrases like "create a new project", "start a new project", "set up a project", "add a project", or when the user wants to kick off something new and needs both a planning document and a Todoist project created together.
+---
+
+# New Project
+
+You help the user create a new project: a folder in their Obsidian vault and a matching Todoist project. Once the project is set up, you hand off to the right skill to generate the PLAN.md.
+
+## Arguments
+
+- `--projects-path <path>` — override the projects root folder. Takes precedence over any CLAUDE.md config. Default: `01-Projects`.
+
+## Configuration
+
+If a `CLAUDE.md` exists at the vault root with a **Chief of Staff** config block, the `projects-path` value there is used as the default — no argument needed. The precedence is:
+
+1. `--projects-path` argument (highest)
+2. `projects-path` in `CLAUDE.md` chief-of-staff config block
+3. Hardcoded default: `01-Projects`
+
+Example `CLAUDE.md` block:
+
+```
+## Chief of Staff
+- projects-path: Projects
+```
+
+---
+
+## Phase 0: Gather Project Info
+
+**First, resolve the projects path.** Check `CLAUDE.md` at vault root for a "Chief of Staff" section and read the `projects-path` value if present. If `--projects-path` was passed, it overrides the CLAUDE.md value. If neither is set, use `01-Projects`.
+
+Then ask the user two questions (they can answer both at once):
+
+1. **Project name** — what's this project called?
+2. **Ownership** — is this _your_ project, or are you tracking it for someone on your team?
+   - _Mine_ → full project plan via `/project-planner`, saved to `<projects-path>/<slug>/`
+   - _Team member's_ → lightweight tracker via `/project-tracker`, saved to `<projects-path>/Watched/<slug>/`
+
+Derive a `slug` from the project name: lowercase, spaces to hyphens, strip special characters (e.g., "API Migration" → `api-migration`).
+
+---
+
+## Phase 1: Confirm Location
+
+Tell the user where things will go before acting:
+
+- **Obsidian folder:** `<projects-path>/<project-name>/` (own) or `<projects-path>/Watched/<project-name>/` (team member's)
+- **Todoist project:** under the matching parent project in Todoist (see Phase 2)
+
+Check that the target folder doesn't already exist. If it does, ask the user whether to continue (they may be setting up a Todoist project for something that already has a folder).
+
+---
+
+## Phase 2: Create Todoist Project
+
+Use the Todoist MCP to find the right parent project, then create the new project under it.
+
+**Step 1 — Find the parent project:**
+
+Call `get-projects` (or equivalent list tool) to fetch all projects. Search for a project whose name matches the projects root:
+
+- For own projects: projects should be nested under "#Parsyl", or a close variant
+- For team member's projects: should be nested under "#Watched" or a close variant
+
+If no matching parent is found, create the Todoist project at the top level and note that the user may want to move it manually.
+
+**Step 2 — Create the project:**
+
+Call `create-project` with:
+
+- `name`: the project name (not the slug — use the display name)
+- `parent_id`: ID of the parent project found above (omit if top-level)
+
+Tell the user: "Created Todoist project **[name]**" and note the parent it was placed under.
+
+**If the Todoist MCP doesn't expose project management tools**, fall back to the Todoist REST API v1:
+
+```
+POST https://api.todoist.com/api/v1/projects
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{ "name": "<project name>", "parent_id": "<parent_id>" }
+```
+
+The API returns a project object — capture the `id` for reference.
+
+> **API note:** Todoist API v1 response shape wraps lists in a named object key (e.g., `{ results: [...] }`). When fetching all projects, check the top-level key whose value is an array.
+
+---
+
+## Phase 3: Hand Off to Planning Skill
+
+Once the Todoist project is created, invoke the appropriate skill. Pass the project name and target save path as context so the skill doesn't need to re-ask.
+
+**Own project → `/project-planner`**
+
+Say:
+
+> "Todoist project created. Now let's build out the plan — I'll run /project-planner for you."
+> "When it asks where to save, the target path is `<projects-path>/<slug>/PLAN.md`."
+
+Then invoke `/project-planner`. It will interview the user and write the PLAN.md. Remind it (in your handoff context) to save the file at `<projects-path>/<slug>/PLAN.md`.
+
+**Team member's project → `/project-tracker`**
+
+Say:
+
+> "Todoist project created. Let me set up the tracker now — I'll run /project-tracker for you."
+
+Then invoke `/project-tracker`. Remind it (in your handoff context) to save the file at `<projects-path>/Watched/<slug>/PLAN.md` — not the default `Watched/<slug>/PLAN.md`, since we're placing it under the configured projects path.

--- a/chief-of-staff/skills/project-monitor/SKILL.md
+++ b/chief-of-staff/skills/project-monitor/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: project-monitor
+description: Compares active project PLAN.md files against live Todoist task state. Identifies stalled projects, task gaps between the plan and Todoist, undocumented work, and approaching deadlines. Can update PLAN.md files and create missing Todoist tasks. Can be run standalone or invoked silently by /wrap-week in summary mode. Trigger when the user says "check my projects", "project health", "project status", "monitor projects", or invokes /project-monitor. Must be run from the root of the Obsidian vault.
+---
+
+# Project Monitor
+
+You are helping the user keep their active projects on track. This skill compares what's in each project's PLAN.md against what's actually happening in Todoist — surfacing gaps, stalled projects, undocumented work, and upcoming deadlines before they become problems.
+
+This skill can run in two modes:
+
+- **Standalone** (default): Full interactive session — presents analysis per project, asks the user for decisions, and takes actions (update plans, create tasks, mark complete).
+- **Summary mode** (`--summary`): Silent data-gathering only. Returns structured output for another skill (e.g., `/wrap-week`) to consume. No interactive prompts, no actions taken.
+
+## Arguments
+
+- `--projects-path <path>` — override projects folder (default: `01-Projects`)
+- `--summary` — run in summary mode (no interaction, structured output only)
+
+## Vault Paths (relative to vault root)
+
+- Projects: `01-Projects/` (each project is a subfolder with a `PLAN.md` file)
+
+---
+
+## Phase 1: Load Projects
+
+Read all `01-Projects/*/PLAN.md` files. From each, extract frontmatter:
+- `name` — project name
+- `description` — keyword-rich summary
+- `due_date` — deadline (optional)
+- `area` — owning AOR
+
+Also read the `## Tasks` section of each PLAN.md to get the list of planned tasks.
+
+If no projects are found, note that and skip to closing.
+
+---
+
+## Phase 2: Load Todoist State (run in parallel)
+
+For each project, fetch tasks from the matching Todoist project (match by `name` from frontmatter — use the project name as the Todoist project filter):
+
+- All open tasks
+- Tasks completed in the last 7 days
+- Task due dates
+
+Categorize per project:
+- **Open tasks** — not yet complete
+- **Recently completed** — done in the last 7 days
+- **Overdue tasks** — past due date
+- **No-date tasks** — open but no due date
+
+---
+
+## Phase 3: Gap Analysis
+
+For each project, compare the PLAN.md task list against Todoist:
+
+**Missing tasks:** Tasks listed in PLAN.md's `## Tasks` section that don't have a matching open or completed Todoist task. These may have been completed outside Todoist, skipped, or forgotten.
+
+**Undocumented work:** Open Todoist tasks that have no corresponding item in PLAN.md. The plan may be stale.
+
+**Stalled:** No tasks completed in the last 7 days AND no recently-added open tasks.
+
+**Approaching deadline:** `due_date` is within 14 days and open tasks remain.
+
+**Overdue:** `due_date` is in the past and open tasks remain.
+
+**On track:** Has recent activity, no deadline concern, plan and Todoist are reasonably aligned.
+
+---
+
+## Phase 4: Classify and Report
+
+Assign each project one status: `on-track`, `stalled`, `needs-attention`, `approaching-deadline`, or `overdue`
+
+Priority for classification (apply the highest-severity that fits):
+1. `overdue` — past deadline with open tasks
+2. `approaching-deadline` — deadline within 14 days with open tasks
+3. `needs-attention` — significant task gaps (≥3 missing tasks or ≥3 undocumented tasks)
+4. `stalled` — no activity in 7+ days
+5. `on-track` — everything else
+
+### Summary mode (`--summary`)
+
+Return a structured list without any user interaction:
+
+```
+[Project Name] | status: [status] | due: [due_date or "none"] | note: [1-line flag reason or "—"]
+```
+
+Exit after returning the list. No further interaction.
+
+---
+
+### Standalone mode
+
+For each project, present:
+
+```
+### [Project Name]
+Status: [status emoji + label]  |  Deadline: [due_date or "none"]
+Area: [area]
+
+[Gap analysis — only show what's relevant:]
+- Missing tasks (in plan, not in Todoist): [list or "none"]
+- Undocumented work (in Todoist, not in plan): [list or "none"]
+- Overdue Todoist tasks: [list or "none"]
+- Last activity: [X days ago / "this week"]
+```
+
+Status emoji key:
+- `on-track` → ✅
+- `stalled` → 🔄
+- `needs-attention` → ⚠️
+- `approaching-deadline` → 🔔
+- `overdue` → 🚨
+
+After presenting all projects, ask the user for their decision on each flagged project (anything not `on-track`). Collect all decisions before executing.
+
+For each flagged project, options:
+
+- **Looks good / skip** — no action
+- **Update the plan** → update the `## Tasks` section of PLAN.md to reflect current Todoist state; add an `## Updates` entry with today's date and a brief status note
+- **Create missing tasks** → create the missing Todoist tasks in the matching project
+- **Add a note** → append an entry to `## Updates` in PLAN.md with a blocker note or status update
+- **Mark complete** → ask for confirmation, then archive or mark the project as done (move PLAN.md frontmatter `tags` from `[project]` to `[project, complete]` and add `completed: YYYY-MM-DD`)
+
+---
+
+## Phase 5: Execute Actions (standalone only)
+
+After collecting all decisions:
+
+1. Batch all `add-task` calls for any missing tasks being created
+2. Use the Edit tool to update PLAN.md files — update `## Tasks` lists and append `## Updates` entries
+
+When appending to `## Updates`, use this format:
+
+```markdown
+### YYYY-MM-DD
+
+[Status note — e.g., "On track. 3 tasks completed this week, 2 remaining before phase 2."]
+[Blocker note if applicable — e.g., "Blocked on design review from [person]."]
+```
+
+---
+
+## Closing (standalone only)
+
+Summarize actions taken:
+
+```
+Project monitor complete.
+- [N] projects reviewed
+- [X] on track
+- [Y] updated
+- [Z] tasks created
+```
+
+If any projects are `approaching-deadline` or `overdue` and weren't addressed, call them out explicitly:
+
+```
+⚠️ Still needs attention:
+- [Project Name] — [status] — [due_date]
+```

--- a/chief-of-staff/skills/wrap-week/SKILL.md
+++ b/chief-of-staff/skills/wrap-week/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: wrap-week
-description: Weekly retrospective — pulls completed Todoist tasks, Google Calendar events, and Obsidian daily notes from Monday through today, synthesizes a narrative weekly recap, saves it to Obsidian, and previews next week. Run on Friday afternoon or Sunday evening. Trigger when the user says "wrap up my week", "weekly recap", "weekly review", or invokes /wrap-week. Must be run from the root of the Obsidian vault.
+description: Weekly wrap-up and forward-planning session. Spends 1/3 on this week's retrospective and 2/3 planning next week with clear priorities. Silently runs /project-monitor and /aor-review to inform priority-setting. Finishes by writing the current week's recap and creating next week's planning file. Run on Friday afternoon or Sunday evening. Trigger when the user says "wrap up my week", "weekly recap", "weekly review", or invokes /wrap-week. Must be run from the root of the Obsidian vault.
 ---
 
 # Wrap Week
 
-You are helping the user write a meaningful weekly retrospective. This is a narrative synthesis, not a list dump. The goal is to tell the story of the week in a way that helps the user see patterns, celebrate progress, and prepare thoughtfully for next week.
+You are helping the user close out this week and set up next week for success. The session is intentionally weighted: 1/3 on what happened this week, 2/3 on making sure next week starts with focus and clarity. The output is two files: a completed recap for this week and a pre-populated planning file for next week.
 
 ## Arguments
 
 - `--daily-notes-path <path>` — override daily notes folder (default: `02-AreasOfResponsibility/Daily Notes`)
 - `--weekly-recaps-path <path>` — override weekly recaps folder (default: `02-AreasOfResponsibility/Weekly Recaps`)
 - `--areas-path <path>` — override areas of responsibility root folder (default: `02-AreasOfResponsibility`)
+- `--focus <text>` — user-specified focus area or theme for next week (e.g., `--focus "Q2 planning"`)
 
 ## Vault Paths (relative to vault root)
 
@@ -19,177 +20,182 @@ You are helping the user write a meaningful weekly retrospective. This is a narr
 - Weekly recaps: `02-AreasOfResponsibility/Weekly Recaps/`
 - Areas of responsibility: `02-AreasOfResponsibility/` (subfolders, excluding `Daily Notes`, `Weekly Recaps`, `Notes`)
 
-## Phase 0: Date Setup
+---
 
-Run via Bash:
+## Phase 0: Date Setup
 
 ```bash
 TODAY=$(date +%Y-%m-%d)
-# Day of week as number (1=Mon, 7=Sun)
 DOW=$(date +%u)
-# Monday of current week
 WEEK_START=$(date -v-$((DOW - 1))d +%Y-%m-%d 2>/dev/null || date -d "$(date +%Y-%m-%d) -$(($(date +%u)-1)) days" +%Y-%m-%d)
-# ISO week number
 WEEK_NUM=$(date +%Y-W%V)
-echo "TODAY=$TODAY WEEK_START=$WEEK_START WEEK_NUM=$WEEK_NUM"
+# Next week values
+NEXT_WEEK_START=$(date -v+$((8 - DOW))d +%Y-%m-%d 2>/dev/null || date -d "$(date +%Y-%m-%d) +$((8 - $(date +%u))) days" +%Y-%m-%d)
+NEXT_WEEK_END=$(date -v+$((12 - DOW))d +%Y-%m-%d 2>/dev/null || date -d "$(date +%Y-%m-%d) +$((12 - $(date +%u))) days" +%Y-%m-%d)
+NEXT_WEEK_NUM=$(date -v+7d +%Y-W%V 2>/dev/null || date -d "$(date +%Y-%m-%d) +7 days" +%Y-W%V)
+echo "TODAY=$TODAY WEEK_START=$WEEK_START WEEK_NUM=$WEEK_NUM NEXT_WEEK_START=$NEXT_WEEK_START NEXT_WEEK_END=$NEXT_WEEK_END NEXT_WEEK_NUM=$NEXT_WEEK_NUM"
 ```
 
-Store WEEK_START (Monday), TODAY, and WEEK_NUM (e.g., `2026-W13`).
+Store all variables. WEEK_NUM and NEXT_WEEK_NUM follow ISO format (e.g., `2026-W13`, `2026-W14`).
+
+---
 
 ## Phase 1: Gather the Week's Data
 
-Run in parallel where possible:
+Run all of the following in parallel:
 
-**Completed tasks:** Call `find-completed-tasks` filtered from WEEK_START to TODAY. Group by project. Note the total count.
+**Completed tasks:** `find-completed-tasks` from WEEK_START to TODAY. Group by project. Note total count.
 
-**Incomplete/carried tasks:** Call `find-tasks` filtered to overdue. These are things that were planned but didn't happen this week.
+**Incomplete/overdue tasks:** `find-tasks` filtered to overdue. These are planned items that didn't happen.
 
-**Calendar events:** Call `list-events` on the Google Calendar MCP server for WEEK_START through TODAY. Group by day. Note total meeting hours.
+**This week's calendar:** `list-events` for WEEK_START through TODAY. Group by day. Note total meeting hours and any recurring commitments.
 
-**Daily notes:** For each day Monday through today, attempt to read `02-AreasOfResponsibility/Daily Notes/YYYY-MM-DD.md` using the Read tool. Collect each note that exists. Note how many days have a daily note vs. how many don't.
+**Next week's calendar:** `list-events` for NEXT_WEEK_START through NEXT_WEEK_END. Note meeting load, any heavy days, and commitments that need prep.
 
-If daily notes are sparse or missing, acknowledge that and work with what's available from Todoist and Calendar.
+**Daily notes:** Read each `02-AreasOfResponsibility/Daily Notes/YYYY-MM-DD.md` for Mon–Fri this week. For each note that exists, extract: accomplishments, blockers, recurring themes, any project mentions, and end-of-day reflections. Note how many days have notes vs. don't.
 
-## Phase 2: Synthesize the Weekly Narrative
+**Current week file:** Check if `02-AreasOfResponsibility/Weekly Recaps/WEEK_NUM.md` exists. If so, read it — preserve existing frontmatter and Priorities/Key Projects sections.
 
-Write a narrative recap — not a data dump. Aim for 300–500 words that tell the story of the week. Synthesize across all sources rather than summarizing each one separately.
+---
 
-Structure the narrative around these themes (use judgment about which are relevant this week):
+## Phase 2: Weekly Recap (condensed — ~1/3 of the session)
 
-**The Big Picture**
-What was the dominant theme? Examples: "This was primarily a deep-work week on [project]", "This week was fragmented across multiple initiatives with a heavy meeting load", "A recovery week after last week's crunch."
+Write a tight narrative recap — 150–250 words. This is a synthesis, not a data dump. Write it as if explaining the week to a colleague in two minutes.
+
+Structure:
+
+**The Week in Brief**
+One sentence on the dominant theme (e.g., "A heads-down execution week on [project]", "Heavy meeting load with fragmented focus", "Recovery week after last week's crunch").
 
 **Key Accomplishments**
-3–5 most significant completions, chosen for impact not volume. Not just the most tasks — the most meaningful ones.
-
-**Meetings and Decisions**
-What did the calendar reveal? Any significant conversations, decisions made, or relationships advanced?
+3 most meaningful completions — chosen for impact, not volume. One line each.
 
 **What Didn't Happen**
-Honest acknowledgment of things that were planned but didn't happen. Frame constructively: "X was planned but got displaced by Y." Flag anything deferred multiple weeks in a row.
+1–2 honest sentences. Frame constructively: "X was displaced by Y." Flag anything deferred multiple weeks running.
 
-**Patterns and Observations** (only if the data supports it)
-Examples: "Most productive days were Tuesday/Thursday when you had clear morning blocks", "Three p1 tasks were deferred again — worth a priority audit."
+**Week Patterns** (only if the data supports a clear observation)
+Examples: "Most productive stretch was Tue–Wed before the afternoon standup block", "Three p1 tasks deferred again."
 
-**Tone from Daily Notes** (only if daily notes exist with reflections)
-If end-of-day reflections are present, synthesize the emotional arc of the week honestly.
-
-## Phase 3: Next Week Preview
-
-1. Call `list-events` for next Monday through Friday.
-2. Call `find-tasks` filtered to next week's due dates, plus any still-overdue tasks being carried forward.
-
-Present:
-
-- **Key commitments** — calendar events next week that may need prep
-- **Priorities** — top tasks due next week, especially any carried from this week
-- **Suggested focus** — given this week's patterns, what should next week's emphasis be?
-
-Ask: "Is there anything you want to set as an intention for next week?" Incorporate their answer into the recap note.
-
-## Phase 3b: Areas of Responsibility Review
-
-After the next-week preview, surface the health of your ongoing Areas of Responsibility (AORs) before closing out the week.
-
-### Step 1: Discover areas
-
-List the subfolders of the areas path (default: `02-AreasOfResponsibility/`, overridable via `--areas-path`). Exclude system folders: `Daily Notes`, `Weekly Recaps`, `Notes`. Each remaining subfolder is one AOR. Its name must match the corresponding Todoist project name exactly.
-
-If no subfolders are found (or the path doesn't exist), skip this phase and note it in the recap.
-
-### Step 2: Gather context (run in parallel)
-
-For each AOR folder:
-
-- Read any `.md` files in that folder to understand the area's scope and objective
-- Call `find-tasks` filtered to the matching Todoist project name to fetch all open tasks
-
-### Step 3: Synthesize health per area
-
-For each area, assess:
-
-- Open task count and the age of the oldest task
-- Whether any tasks are overdue or due this week
-- Themes across the open tasks (brief synthesis — what kinds of work are queued?)
-- **Project readiness signal:** If ≥5 open tasks, OR any task is >30 days old, OR tasks appear to cluster around a specific deliverable — proactively suggest spinning up a dedicated project. State your reasoning (e.g., "5 tasks around improving CI/CD pipeline — this looks like a project").
-
-### Step 4: Present and act
-
-For each area, show:
-
-```
-### [Area Name]
-Open tasks: X  |  Oldest: Y days old  [⚠️ if >30 days]
-Themes: [2-3 sentence synthesis]
-[💡 Suggested: Consider spinning up a project — [reason]] ← only if flagged
-```
-
-Then ask the user for their decision on each area (collect all decisions before executing):
-
-- **Looks good** — no action
-- **Schedule a review** → create a task in that Todoist project due next Monday: "Review [Area Name]"
-- **Spin up a project** → ask for project name → create `01-Projects/<Name>/PLAN.md` using the template below
-
-Batch all `add-tasks` calls together, then write any PLAN.md files.
-
-### Project stub template
-
-When creating `01-Projects/<Name>/PLAN.md`:
-
-```markdown
----
-name: <Project Name>
-description: <keyword-rich summary used for machine matching — include system names, team names, business domain, the specific problem and approach. Not a generic summary.>
-due_date: <YYYY-MM-DD — omit entirely if no hard deadline>
-area: <area-name>
-started: <today>
-tags: [project]
----
-
-# <Project Name>
-
-## Overview
-
-<2–4 sentence narrative: why this project exists, who's involved, what's driving it, and any important background. Dense enough to get back up to speed before a meeting.>
-
-## Tasks
-
-- [ ] <!-- Relevant open tasks from the [Area Name] Todoist project -->
-
-## Updates
-
-<!-- Filled in over time as the project progresses -->
-```
-
-After creating the stub, tell the user: "Run `/project-planner` on this project to build out the full plan with phases, objectives, and exit criteria."
+Present the recap to the user. They can confirm it as-is or add a note. Keep this phase brief — the goal is to capture the week, not relitigate it.
 
 ---
 
-## Phase 4: Save Weekly Recap
+## Phase 3: Silent Context Gathering
 
-The weekly recap file may already exist if `/start-week` was run at the beginning of the week. Check first:
+Before priority-setting, invoke both sub-skills in summary mode. Do NOT prompt the user during this phase.
 
-**If the file already exists** at `02-AreasOfResponsibility/Weekly Recaps/WEEK_NUM.md`:
+Run in parallel:
 
-- Read it with the Read tool
-- Preserve the frontmatter, `## Priorities This Week`, and `## Key Projects This Week` sections exactly as written
-- Append or overwrite only the retrospective sections below (The Week in Review, By the Numbers, etc.)
-- Use the Edit tool to replace the placeholder `<!-- wrap-week -->` block if present, or append after the last existing section
+- **`/project-monitor --summary`** — returns a structured list of active projects with status, deadline, and flag notes
+- **`/aor-review --summary`** — returns a structured list of AORs with open task counts, oldest task age, and health flags
 
-**If the file does not exist**, create it with the Write tool using the full template below.
+Store both results internally for use in Phase 4. Do not display them to the user yet.
+
+---
+
+## Phase 4: Priority Synthesis (the core of the session)
+
+Now present the full landscape and work with the user to set 2–3 priorities for next week.
+
+### 4a: Surface the Inputs
+
+Present a structured summary of everything gathered:
+
+```
+## What I'm seeing for next week
+
+**From this week's daily notes:**
+[2–3 themes, blockers, or unresolved items pulled from the notes]
+
+**Active projects:**
+[List each project with its status from Phase 3a — flag stalled/needs-attention/deadline]
+
+**Areas of responsibility:**
+[List flagged areas from Phase 3b with brief reason]
+
+**Next week's calendar:**
+[Total meeting count and hours, any heavy days, key commitments needing prep]
+
+**Carried forward from this week:**
+[Top 3 overdue/unfinished items]
+```
+
+If the user passed `--focus`, surface it here: "You mentioned wanting to focus on [focus] — I'll factor that in."
+
+Then explicitly ask: "Is there anything specific you want to make sure gets done next week, or a theme you want to emphasize?"
+
+### 4b: Propose Priority Candidates
+
+Based on all inputs, propose 4–6 candidate priorities with rationale:
+
+```
+**Candidate priorities for next week:**
+
+1. [Priority name] — [why: e.g., "Project X has 3 open tasks and a deadline in 10 days"]
+2. [Priority name] — [why: e.g., "Stalled since last week — needs a push to move forward"]
+3. [Priority name] — [why: e.g., "AOR [area] has 7 open tasks, oldest is 45 days — time to clear or project-ize"]
+4. [Priority name] — [why: e.g., "You mentioned this in your Tuesday daily note as a blocker"]
+5. [Priority name] — [why: e.g., "Monday has 3 meetings around this topic — good week to make a decision"]
+```
+
+Ask: "Which 2–3 of these do you want as your priorities for next week? You can pick from the list, adjust them, or give me something different."
+
+### 4c: Priority Deep-Dive
+
+For each confirmed priority (one at a time):
+
+1. **Define done:** "What does success look like for this by end of next week?" (brief — one sentence)
+2. **Task check:** Surface any existing Todoist tasks that support this priority. If none exist, note the gap and offer to create a task inline.
+3. **Blockers:** "Anything that needs to happen first, or anyone you need to loop in?"
+
+Keep each deep-dive tight — the goal is clarity, not exhaustive planning.
+
+### 4d: Next Week Framing
+
+After priorities are set, briefly review:
+
+- **Calendar load:** Flag any days with >4 hours of back-to-back meetings
+- **Key meetings to prep for:** Any next-week calendar events needing prep based on the project/AOR context
+- **Known constraints:** Travel, blocked time, dependencies
+
+Ask: "Any intention or theme you want to carry into next week?" Capture their answer for the planning file.
+
+---
+
+## Phase 5: Create Missing Todoist Tasks
+
+For any priority deep-dive that surfaced a task gap, offer to create the tasks now:
+
+"For [Priority], you don't have any open Todoist tasks. Want me to create: [suggested task(s)]?"
+
+Batch all `add-task` calls together after confirming with the user.
+
+---
+
+## Phase 6: Write Output Files
+
+### File 1 — Current Week Recap
+
+Path: `02-AreasOfResponsibility/Weekly Recaps/WEEK_NUM.md`
+
+**If the file already exists** (from `/start-week`):
+- Read it, preserve frontmatter + `## Priorities This Week` + `## Key Projects This Week` exactly
+- Fill in or replace the retrospective sections (The Week in Review, By the Numbers, Highlights, Carried Forward, Next Week, Intentions for Next Week, Areas Reviewed)
+
+**If the file does not exist**, create it with the full template.
 
 ```markdown
 ---
 date-range: WEEK_START to TODAY
 week: WEEK_NUM
-tags: [weekly-recap]
+tags: [weekly-recap, weekly-plan]
 ---
 
 # Week of [Month Day] — [Month Day, Year]
 
 ## The Week in Review
 
-[Narrative from Phase 2 — 300–500 words]
+[Narrative from Phase 2 — 150–250 words]
 
 ## By the Numbers
 
@@ -200,33 +206,84 @@ tags: [weekly-recap]
 
 ## Highlights
 
-[Bullet list of 3–5 key accomplishments]
+- [Top accomplishment 1]
+- [Top accomplishment 2]
+- [Top accomplishment 3]
 
 ## Carried Forward
 
 [Incomplete items and where they're headed]
 
-## Next Week
-
-[Preview from Phase 3 — calendar commitments and top priorities]
-
-## Intentions for Next Week
-
-[User's stated intention, or "—" if skipped]
-
 ## Areas Reviewed
 
-| Area        | Open Tasks | Oldest Task | Action Taken                                           |
-| ----------- | ---------- | ----------- | ------------------------------------------------------ |
-| [Area Name] | X          | Y days      | Looks good / Scheduled review / Spun up [Project Name] |
+| Area        | Open Tasks | Oldest Task | Health  | Note                                  |
+| ----------- | ---------- | ----------- | ------- | ------------------------------------- |
+| [Area Name] | X          | Y days      | ok/flag | [action taken or observation]         |
 ```
 
-Tell the user: "Saved to `02-AreasOfResponsibility/Weekly Recaps/WEEK_NUM.md`"
+### File 2 — Next Week Planning File
+
+Path: `02-AreasOfResponsibility/Weekly Recaps/NEXT_WEEK_NUM.md`
+
+Check if this file already exists. If it does, skip creating it (don't overwrite manual edits).
+
+If it does not exist, create it pre-populated with the priorities and project context from this session:
+
+```markdown
+---
+date-range: NEXT_WEEK_START to NEXT_WEEK_END
+week: NEXT_WEEK_NUM
+tags: [weekly-recap, weekly-plan]
+---
+
+# Week of [Next Week Month Day] — [Next Week Month Day, Year]
+
+## Priorities This Week
+
+1. [Priority 1 from Phase 4c]
+   [Success definition from deep-dive]
+2. [Priority 2 from Phase 4c]
+   [Success definition from deep-dive]
+3. [Priority 3 from Phase 4c — omit if only 2 were set]
+   [Success definition from deep-dive]
+
+## Key Projects This Week
+
+[One line per active project with status from project-monitor summary — name · status · deadline if any]
+
+---
+<!-- The sections below are filled in by /wrap-week at the end of next week -->
+
+## The Week in Review
+## By the Numbers
+## Highlights
+## Carried Forward
+## Areas Reviewed
+```
+
+---
+
+## Closing
+
+Tell the user:
+
+```
+Week [WEEK_NUM] wrapped. Next week's planning file is ready at Weekly Recaps/[NEXT_WEEK_NUM].md.
+
+You're starting [next Monday's date] with [N] priorities:
+1. [Priority 1]
+2. [Priority 2]
+[3. Priority 3 if set]
+
+Run /start-week on Monday to pull your briefing, or your planning file is already there if you want to jump straight in.
+```
+
+---
 
 ## Quality Notes
 
-- The narrative should feel human and thoughtful — write it as if explaining the week to a colleague, not generating a report
-- Don't list every completed task — curate and interpret
-- If a week had sparse data, be honest about that rather than padding the narrative
-- The recap should be something the user would find meaningful to re-read months later
-- ISO week filenames (`2026-W13.md`) sort naturally and are easy to query for quarterly reviews
+- Keep Phase 2 tight — resist the urge to expand the retrospective. The value is in the forward planning.
+- Priority deep-dives should feel like a brief alignment conversation, not a planning marathon. One sentence of "done" is enough.
+- The next-week file should feel ready to use on Monday, not like a rough draft.
+- Don't surface every project and area in the priority candidates — curate to the most actionable 4–6. The user can volunteer others.
+- If a week had sparse data (few daily notes, light task history), be honest about that and lean on calendar + project state instead.


### PR DESCRIPTION
Addresses #11 and #7 

- Rewrote /wrap-week to spend 1/3 on retrospective and 2/3 on forward planning; now creates next week's planning file during the Friday session
- Extracted AOR review from wrap-week into standalone /aor-review skill with dual standalone/summary modes
- New /project-monitor skill compares PLAN.md task lists against live Todoist state, classifying projects by health and surfacing gaps/deadlines
- wrap-week silently invokes both sub-skills in summary mode to inform priority-setting without interrupting the session flow
- Added /new-project skill and Slack integration to /finish-day
- Updated README for all new skills, arguments, and workflow changes